### PR TITLE
Hot fix number to string

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -104,11 +104,6 @@ exports.buildJobParams = (paramsList, inputParams) => {
 
     switch (type) {
       case "number": {
-        // let val = parseFloat(inputValue);
-        // if (val === NaN) {
-        //   throw `param: ${name} cannot parse to number`;
-        // }
-        // jobParams[name] = val;
         const val =
           typeof inputValue === "number" ? inputValue.toString() : inputValue;
         jobParams[name] = val;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -104,10 +104,13 @@ exports.buildJobParams = (paramsList, inputParams) => {
 
     switch (type) {
       case "number": {
-        let val = parseFloat(inputValue);
-        if (val === NaN) {
-          throw `param: ${name} cannot parse to number`;
-        }
+        // let val = parseFloat(inputValue);
+        // if (val === NaN) {
+        //   throw `param: ${name} cannot parse to number`;
+        // }
+        // jobParams[name] = val;
+        const val =
+          typeof inputValue === "number" ? inputValue.toString() : inputValue;
         jobParams[name] = val;
         break;
       }
@@ -141,13 +144,7 @@ exports.buildJobParams = (paramsList, inputParams) => {
 
 exports.validateSubmission = (props) => {
   let { tags, jobSpec, queue, priority } = props;
-  if (
-    !tags ||
-    !jobSpec ||
-    priority === "" ||
-    priority === undefined ||
-    !queue
-  )
+  if (!tags || !jobSpec || priority === "" || priority === undefined || !queue)
     return false;
   return true;
 };


### PR DESCRIPTION
not coercing numbers to strings cause an error in the backend:
```
raised unexpected: Exception('Job Submitter Job failed to submit all actions')
Traceback (most recent call last):
  File "/export/home/hysdsops/verdi/lib/python3.8/site-packages/celery/app/trace.py", line 412, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/export/home/hysdsops/verdi/lib/python3.8/site-packages/celery/app/trace.py", line 704, in __protected_call__
    return self.run(*args, **kwargs)
  File "/export/home/hysdsops/verdi/ops/hysds/hysds/task_worker.py", line 127, in run_task
    result = func(*args, **kwargs)
  File "/export/home/hysdsops/verdi/ops/hysds_commons/hysds_commons/job_iterator.py", line 131, in iterate
    raise Exception("Job Submitter Job failed to submit all actions")
Exception: Job Submitter Job failed to submit all actions
```

need to force them to string types
TODO: will probably need to refactor the backend to allow for actual `number` types instead of forcing everything to be a `string`