### PR TITLE
using NavLink instead of Link to save state usage for active page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/HeaderBar/index.jsx
+++ b/src/components/HeaderBar/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import { connect } from "react-redux";
 import { editTheme } from "../../redux/actions";
 import { Button } from "../Buttons";
@@ -18,14 +18,13 @@ import style from "../../style/global.css";
 import "./style.css";
 
 export function HeaderLink(props) {
-  const { title, href, active } = props;
-
-  let className = "header-bar-link";
-  if (active) className = `${className} active-link`;
+  const { title, href } = props;
 
   return (
-    <li className={className} {...props}>
-      <Link to={{ pathname: href, state: "desiredState" }}>{title}</Link>
+    <li className="header-bar-link" {...props}>
+      <NavLink to={{ pathname: href }} activeClassName="active-link">
+        {title}
+      </NavLink>
     </li>
   );
 }

--- a/src/components/HeaderBar/style.css
+++ b/src/components/HeaderBar/style.css
@@ -35,7 +35,7 @@
 }
 
 .header-bar-link .active-link {
-  background-color: #1c5bca;
+  background-color: #7ba6f1;
 }
 
 .header-bar-buffer {
@@ -91,7 +91,7 @@
   color: var(--dark-theme-color);
 }
 
-.__theme-dark .header-bar-link.active-link {
+.__theme-dark .header-bar-link .active-link {
   background-color: var(--dark-theme-light);
 }
 

--- a/src/pages/Figaro/index.jsx
+++ b/src/pages/Figaro/index.jsx
@@ -69,7 +69,7 @@ class Figaro extends React.Component {
           <title>Figaro - Home</title>
           <meta name="description" content="Helmet application" />
         </Helmet>
-        <HeaderBar title="HySDS" theme={classTheme} active="figaro">
+        <HeaderBar title="HySDS" theme={classTheme}>
           <HeaderLink href="/tosca" title="Tosca" active={0} />
           <HeaderLink href="/figaro" title="Figaro" active={1} />
           <DropdownSources />

--- a/src/pages/Tosca/index.jsx
+++ b/src/pages/Tosca/index.jsx
@@ -92,7 +92,7 @@ class Tosca extends React.Component {
           <title>Tosca - Home</title>
           <meta name="description" content="Helmet application" />
         </Helmet>
-        <HeaderBar title="HySDS" theme={classTheme} active="tosca">
+        <HeaderBar title="HySDS" theme={classTheme}>
           <HeaderLink href="/tosca" title="Tosca" active={1} />
           <HeaderLink href="/figaro" title="Figaro" active={0} />
           <DropdownSources />


### PR DESCRIPTION
`NavLink` is cleaner than using `Link` b/c you dont need to pass in a prop to denote if the link is active
https://reactrouter.com/web/api/NavLink