### PR TITLE
job_detail hot fix: remove .keyword from figaro template

### DIFF
--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -74,7 +74,7 @@ exports.FILTERS = [
   },
   {
     componentId: "job_detail",
-    dataField: "msg.keyword",
+    dataField: "msg",
     title: "Job Detail",
     type: "single",
   },


### PR DESCRIPTION
During testing with a fresh new deployment, it was discovered that the Job Detail facet on the sidebar was no longer being shown. In talking with @DustinKLo , since `msg` is already defined as type keyword in the ES template, https://github.com/hysds/hysds/blob/aa347b05ad64874f6833b8b484c93f3e958e14d0/configs/logstash/job_status.template#L32-L37, the Figaro template no longer needs the `.keyword`. Therefore, it can be removed. When I did that, I was able to once again see the `Job Detail` facet:

![image](https://user-images.githubusercontent.com/42812746/125656724-cb9afe2a-6bc1-438f-8f2b-a51856040032.png)
