### PR TITLE
HC-417: Expose job redelivery flag as a facet in Figaro

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -106,6 +106,12 @@ exports.FILTERS = [
     title: "Endpoint ID",
     type: "single",
   },
+  {
+    componentId: "redelivered",
+    dataField: "job.delivery_info.redelivered",
+    title: "Redelivered",
+    type: "single"
+  }
 ];
 
 exports.SORT_OPTIONS = ["@timestamp"];
@@ -131,6 +137,7 @@ exports.QUERY_LOGIC = {
     "payload_id",
     "timestamp",
     "endpoint_id",
+    "redelivered",
   ],
 };
 
@@ -163,4 +170,5 @@ exports.FIELDS = [
   "user_tags",
   "dedup_job",
   "endpoint_id",
+  "job.delivery_info.redelivered",
 ];

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -24,6 +24,12 @@ exports.FILTERS = [
     sortBy: "asc",
   },
   {
+    componentId: "redelivered",
+    dataField: "job.delivery_info.redelivered",
+    title: "Redelivered",
+    type: "single"
+  },
+  {
     componentId: "tags",
     dataField: "tags.keyword",
     title: "Tags",
@@ -105,12 +111,6 @@ exports.FILTERS = [
     dataField: "endpoint_id.keyword",
     title: "Endpoint ID",
     type: "single",
-  },
-  {
-    componentId: "redelivered",
-    dataField: "job.delivery_info.redelivered",
-    title: "Redelivered",
-    type: "single"
   }
 ];
 


### PR DESCRIPTION
This PR exposes the job redelivery flag as a facet in Figaro. This will help in more easily determining when a job had to be re-queued due to spot termination or a job worker going offline, where another worker has to pick up the job:

![image](https://user-images.githubusercontent.com/42812746/167948310-12d63b66-3357-4ae6-a6ab-be211dc625e2.png)

