### PR TITLE
HC-423 - Selecting a redelivery facet yields no results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/SidebarFilters/index.jsx
+++ b/src/components/SidebarFilters/index.jsx
@@ -42,6 +42,27 @@ function Filter({
           className="reactivesearch-input reactivesearch-date"
         />
       );
+    case "bool":
+    case "boolean":
+      return (
+        <SingleList
+          componentId={componentId}
+          key={componentId}
+          dataField={dataField}
+          title={title}
+          URLParams={true}
+          react={queryLogic}
+          className="reactivesearch-input"
+          transformData={(list) =>
+            list
+              .filter((d) => d.key === 1 || d.key === 0)
+              .map((d) => ({
+                key: d.key_as_string,
+                doc_count: d.doc_count,
+              }))
+          }
+        />
+      );
     case "single":
     default:
       return (

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -27,7 +27,7 @@ exports.FILTERS = [
     componentId: "redelivered",
     dataField: "job.delivery_info.redelivered",
     title: "Redelivered",
-    type: "single"
+    type: "boolean",
   },
   {
     componentId: "tags",
@@ -111,7 +111,7 @@ exports.FILTERS = [
     dataField: "endpoint_id.keyword",
     title: "Endpoint ID",
     type: "single",
-  }
+  },
 ];
 
 exports.SORT_OPTIONS = ["@timestamp"];
@@ -166,9 +166,9 @@ exports.FIELDS = [
   "job.job_info.time_start",
   "job.job_info.time_end",
   "job.job_info.metrics.products_staged.id",
+  "job.delivery_info.redelivered",
   "event.traceback",
   "user_tags",
   "dedup_job",
   "endpoint_id",
-  "job.delivery_info.redelivered",
 ];


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-423
- added new filter type called `bool`/`boolean`
- fixed `redelivered` facet in `figaro.template.js`
- bumped version

Reactivesearch will handle boolean values by changing it from `true/false` to `0/1`, but this will raise an error with Elasticsearch:
```json
{
  "root_cause": [
    {
      "type": "query_shard_exception",
      "reason": "failed to create query: Can't parse boolean value [1], expected [true] or [false]",
      "index_uuid": "uaP1BBtoS7GuG3PgOs-3tA",
      "index": "grq_v1.1_s1-iw_slc"
    }
  ]
}
```

[Reactivesearch](https://opensource.appbase.io/reactive-manual/list-components/singlelist.html)'s `Singlelist` component has a prop called `transformData` which:
> allows transforming the data to render inside the list. You can change the order, remove, or add items, transform their values with this method. It provides the data as param which is an array of objects of shape `{ key: <string>, doc_count: <number> }` and expects you to return the array of objects of same shape.

added a new filter type in `SidebarFilters` for `bool/boolean` value to properly facet for boolean fields, make sure to add it to `exports.FILTERS`:
```javascript
exports.FILTERS = [
  {
    componentId: "bool_value",
    dataField: "bool_value",
    title: "Bool Value",
    type: "boolean", // <-- here
    size: 1000,
  },
  ...
]
```

the elasticsearch search query will now look like:
```javascript
{
  "query": {
    "bool": {
      "must": [{ "bool": { "must": [{ "term": { "bool_value": "true" } }] } }]  // <-- here
    }
  },
  "size": 10,
  "aggs": { ... },
  "_source": {
    "includes": [ ... ],
    "excludes": []
  },
  "from": 0
}

```
### Before:
<img width="301" alt="Screen Shot 2022-05-26 at 12 02 47 PM" src="https://user-images.githubusercontent.com/13371881/170558533-c8ff744b-03ea-401d-8260-bfb263025670.png">

### After:
<img width="308" alt="Screen Shot 2022-05-26 at 10 51 27 AM" src="https://user-images.githubusercontent.com/13371881/170554768-14910757-087f-4b6e-a6d9-aea782e2d651.png">
<img width="1134" alt="Screen Shot 2022-05-26 at 10 51 04 AM" src="https://user-images.githubusercontent.com/13371881/170554759-24275855-e851-43f0-b563-2f16022c26f3.png">
<img width="1103" alt="Screen Shot 2022-05-26 at 10 51 39 AM" src="https://user-images.githubusercontent.com/13371881/170554770-6d32b88f-b655-46ea-9a8e-72267b10e5e1.png">

