### PR TITLE
Sort elasticsearch results through the table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/DataTable/index.jsx
+++ b/src/components/DataTable/index.jsx
@@ -5,7 +5,7 @@ import ReactTable from "react-table";
 import "react-table/react-table.css";
 import "./style.css";
 
-function DataTable({ data, columns, sortHandler }) {
+function DataTable({ data, columns, sortColumn, sortOrder, sortHandler }) {
   return (
     <ReactTable
       manual
@@ -21,6 +21,12 @@ function DataTable({ data, columns, sortHandler }) {
         const sortKey = column.keyword ? `${col.id}.keyword` : col.id;
         if (sortHandler) sortHandler(sortKey, direction);
       }}
+      defaultSorted={[
+        {
+          id: sortColumn.replace(".keyword", ""),
+          desc: sortOrder === "desc" ? true : false,
+        },
+      ]}
     />
   );
 }
@@ -28,6 +34,8 @@ function DataTable({ data, columns, sortHandler }) {
 DataTable.propTypes = {
   data: PropTypes.array.isRequired,
   columns: PropTypes.array.isRequired,
+  sortOrder: PropTypes.string,
+  sortHandler: PropTypes.string,
   sortHandler: PropTypes.func,
 };
 

--- a/src/components/DataTable/index.jsx
+++ b/src/components/DataTable/index.jsx
@@ -2,34 +2,33 @@ import React from "react";
 import PropTypes from "prop-types";
 import ReactTable from "react-table";
 
-import { GRQ_DISPLAY_COLUMNS } from "../../config/tosca";
-
 import "react-table/react-table.css";
 import "./style.css";
 
-function DataTable(props) {
-  const { data } = props;
+function DataTable({ data, columns, sortHandler }) {
   return (
     <ReactTable
       manual
       data={data}
-      columns={GRQ_DISPLAY_COLUMNS}
+      columns={columns}
       showPagination={false}
       showPageSizeOptions={false}
       pageSize={data.length}
-      sortable={false}
-      defaultSorted={[
-        {
-          id: props.sortColumn,
-          desc: props.sortOrder === "desc" ? true : false,
-        },
-      ]}
+      sortable={sortHandler ? true : false}
+      onSortedChange={(sorted, column) => {
+        const col = sorted[0];
+        const direction = col.desc ? "desc" : "asc";
+        const sortKey = column.keyword ? `${col.id}.keyword` : col.id;
+        if (sortHandler) sortHandler(sortKey, direction);
+      }}
     />
   );
 }
 
 DataTable.propTypes = {
   data: PropTypes.array.isRequired,
+  columns: PropTypes.array.isRequired,
+  sortHandler: PropTypes.func,
 };
 
 export default DataTable;

--- a/src/components/FigaroDataViewer/index.jsx
+++ b/src/components/FigaroDataViewer/index.jsx
@@ -16,7 +16,8 @@ const createJobUrl = (jobUrl) => {
   return newJobUrl + "/";
 };
 
-export const FigaroDataViewer = ({ res }) => {
+export const FigaroDataViewer = (props) => {
+  const { res } = props;
   const [validJobLink, setJobLink] = useState(false);
 
   const [viewType, setViewType] = useState("traceback");
@@ -211,4 +212,5 @@ export const FigaroDataViewer = ({ res }) => {
 
 FigaroDataViewer.propTypes = {
   res: PropTypes.object.isRequired,
+  editCustomFilterId: PropTypes.func.isRequired,
 };

--- a/src/components/FigaroDataViewer/index.jsx
+++ b/src/components/FigaroDataViewer/index.jsx
@@ -211,27 +211,5 @@ export const FigaroDataViewer = (props) => {
 };
 
 FigaroDataViewer.propTypes = {
-  res: PropTypes.object.isRequired,
+  data: PropTypes.object.isRequired,
 };
-
-export function FigaroDataTable(props) {
-  const { columns, data, sortColumn, sortOrder } = props;
-
-  return (
-    <ReactTable
-      manual
-      data={data}
-      columns={columns}
-      showPagination={false}
-      showPageSizeOptions={false}
-      pageSize={data.length}
-      sortable={false}
-      defaultSorted={[
-        {
-          id: sortColumn,
-          desc: sortOrder === "desc" ? true : false,
-        },
-      ]}
-    />
-  );
-}

--- a/src/components/FigaroDataViewer/index.jsx
+++ b/src/components/FigaroDataViewer/index.jsx
@@ -16,8 +16,7 @@ const createJobUrl = (jobUrl) => {
   return newJobUrl + "/";
 };
 
-export const FigaroDataViewer = (props) => {
-  const { res } = props;
+export const FigaroDataViewer = ({ res }) => {
   const [validJobLink, setJobLink] = useState(false);
 
   const [viewType, setViewType] = useState("traceback");
@@ -211,5 +210,5 @@ export const FigaroDataViewer = (props) => {
 };
 
 FigaroDataViewer.propTypes = {
-  data: PropTypes.object.isRequired,
+  res: PropTypes.object.isRequired,
 };

--- a/src/components/FigaroResultsList/index.jsx
+++ b/src/components/FigaroResultsList/index.jsx
@@ -142,6 +142,8 @@ class FigaroResultsList extends React.Component {
                     <DataTable
                       data={data}
                       columns={FIGARO_DISPLAY_COLUMNS}
+                      sortColumn={this.state.sortColumn}
+                      sortOrder={this.state.sortOrder}
                       sortHandler={this.handleTableSort}
                     />
                   ) : null

--- a/src/components/FigaroResultsList/index.jsx
+++ b/src/components/FigaroResultsList/index.jsx
@@ -4,10 +4,9 @@ import { connect } from "react-redux"; // redux
 import { ReactiveList } from "@appbaseio/reactivesearch"; // reactivesearch
 import { retrieveData, editCustomFilterId } from "../../redux/actions";
 
-import {
-  FigaroDataViewer,
-  FigaroDataTable,
-} from "../../components/FigaroDataViewer";
+import { FigaroDataViewer } from "../../components/FigaroDataViewer";
+
+import DataTable from "../../components/DataTable";
 
 import {
   ToggleSlider,
@@ -19,7 +18,6 @@ import {
 import {
   QUERY_LOGIC,
   FIGARO_DISPLAY_COLUMNS,
-  SORT_OPTIONS,
   FIELDS,
 } from "../../config/figaro";
 
@@ -65,6 +63,9 @@ class FigaroResultsList extends React.Component {
     localStorage.setItem(SORT_DIRECTION_STORE, e.target.value);
   };
 
+  handleTableSort = (sortColumn, direction) =>
+    this.setState({ sortColumn, sortOrder: direction });
+
   render() {
     const { pageSize, tableView, sortColumn, sortOrder } = this.state;
 
@@ -93,7 +94,9 @@ class FigaroResultsList extends React.Component {
             label="Sort By: "
             value={sortColumn}
             onChange={this.handleSortColumn}
-            options={SORT_OPTIONS}
+            options={FIGARO_DISPLAY_COLUMNS.filter((d) => d.accessor).map((d) =>
+              d.keyword ? `${d.accessor}.keyword` : d.accessor
+            )}
           />
           <SortDirection
             value={sortOrder}
@@ -133,9 +136,10 @@ class FigaroResultsList extends React.Component {
             tableView
               ? ({ data }) =>
                   data.length > 0 ? (
-                    <FigaroDataTable
+                    <DataTable
                       data={data}
                       columns={FIGARO_DISPLAY_COLUMNS}
+                      sortHandler={this.handleTableSort}
                     />
                   ) : null
               : null
@@ -144,6 +148,11 @@ class FigaroResultsList extends React.Component {
             <h3 className="figaro-result-stats">{`${stats.numberOfResults} results`}</h3>
           )}
           includeFields={FIELDS ? FIELDS : null}
+          onError={(e) => {
+            if (e.responses) {
+              alert(JSON.stringify(e.responses));
+            }
+          }}
         />
       </div>
     );

--- a/src/components/FigaroResultsList/index.jsx
+++ b/src/components/FigaroResultsList/index.jsx
@@ -63,8 +63,11 @@ class FigaroResultsList extends React.Component {
     localStorage.setItem(SORT_DIRECTION_STORE, e.target.value);
   };
 
-  handleTableSort = (sortColumn, direction) =>
+  handleTableSort = (sortColumn, direction) => {
     this.setState({ sortColumn, sortOrder: direction });
+    localStorage.setItem(SORT_FIELD_STORE, sortColumn);
+    localStorage.setItem(SORT_DIRECTION_STORE, direction);
+  };
 
   render() {
     const { pageSize, tableView, sortColumn, sortOrder } = this.state;
@@ -149,9 +152,7 @@ class FigaroResultsList extends React.Component {
           )}
           includeFields={FIELDS ? FIELDS : null}
           onError={(e) => {
-            if (e.responses) {
-              alert(JSON.stringify(e.responses));
-            }
+            if (e.responses) alert(JSON.stringify(e.responses));
           }}
         />
       </div>

--- a/src/components/TableOptions/index.jsx
+++ b/src/components/TableOptions/index.jsx
@@ -25,7 +25,7 @@ export function SortOptions(props) {
         </option>
         {options.map((field) => (
           <option key={`sort-column-${field}`} value={field}>
-            {field}
+            {field.replace(".keyword", "")}
           </option>
         ))}
       </select>

--- a/src/components/TableOptions/index.jsx
+++ b/src/components/TableOptions/index.jsx
@@ -20,7 +20,7 @@ export function SortOptions(props) {
       <span>{props.label || "Label: "} </span>
       <select className="sort-column-dropdown" {...props}>
         <option key="sort-column-none" value="None">
-          None
+          -
         </option>
         {props.options.map((field) => (
           <option key={`sort-column-${field}`} value={field}>

--- a/src/components/TableOptions/index.jsx
+++ b/src/components/TableOptions/index.jsx
@@ -15,14 +15,15 @@ export function ToggleSlider(props) {
 }
 
 export function SortOptions(props) {
+  const { options, label } = props;
   return (
     <div className="sort-results-select-wrapper">
-      <span>{props.label || "Label: "} </span>
+      <span>{label || "Label: "} </span>
       <select className="sort-column-dropdown" {...props}>
         <option key="sort-column-none" value="None">
           -
         </option>
-        {props.options.map((field) => (
+        {options.map((field) => (
           <option key={`sort-column-${field}`} value={field}>
             {field}
           </option>

--- a/src/components/TableOptions/style.css
+++ b/src/components/TableOptions/style.css
@@ -82,7 +82,7 @@ input:checked + .slider:before {
 .sort-column-dropdown,
 .sort-order-dropdown {
   height: 29px;
-  font-size: 16px;
+  font-size: 14px;
   width: 120px;
   border-radius: 5px;
   background-color: #ffffff;

--- a/src/components/ToscaDataViewer/index.jsx
+++ b/src/components/ToscaDataViewer/index.jsx
@@ -46,7 +46,7 @@ const ToscaDataViewer = (props) => {
         id: {res._id}
       </a>
       {res["@timestamp"] ? (
-        <div>ingest timestamp: {res["@timestamp"]}</div>
+        <div>last modified: {res["@timestamp"]}</div>
       ) : null}
       <UserTags
         tags={userTags}

--- a/src/components/ToscaResultsList/index.jsx
+++ b/src/components/ToscaResultsList/index.jsx
@@ -69,8 +69,11 @@ class ResultsList extends React.Component {
     localStorage.setItem(SORT_DIRECTION_STORE, e.target.value);
   };
 
-  handleTableSort = (sortColumn, direction) =>
+  handleTableSort = (sortColumn, direction) => {
     this.setState({ sortColumn, sortOrder: direction });
+    localStorage.setItem(SORT_FIELD_STORE, sortColumn);
+    localStorage.setItem(SORT_DIRECTION_STORE, direction);
+  };
 
   renderTable = ({ data }) =>
     data.length > 0 ? (
@@ -144,9 +147,7 @@ class ResultsList extends React.Component {
           renderItem={tableView ? null : this.resultsListHandler}
           render={tableView ? this.renderTable : null}
           onError={(e) => {
-            if (e.responses) {
-              alert(JSON.stringify(e.responses));
-            }
+            if (e.responses) alert(JSON.stringify(e.responses));
           }}
           sortOptions={sortOptions}
           includeFields={FIELDS ? FIELDS : null}

--- a/src/components/ToscaResultsList/index.jsx
+++ b/src/components/ToscaResultsList/index.jsx
@@ -80,6 +80,8 @@ class ResultsList extends React.Component {
       <DataTable
         data={data}
         columns={GRQ_DISPLAY_COLUMNS}
+        sortColumn={this.state.sortColumn}
+        sortOrder={this.state.sortOrder}
         sortHandler={this.handleTableSort}
       />
     ) : null;

--- a/src/components/ToscaResultsList/index.jsx
+++ b/src/components/ToscaResultsList/index.jsx
@@ -14,7 +14,7 @@ import {
   SortDirection,
   PageSizeOptions,
 } from "../../components/TableOptions";
-import { SORT_OPTIONS, FIELDS } from "../../config/tosca";
+import { FIELDS, GRQ_DISPLAY_COLUMNS } from "../../config/tosca";
 
 import "./style.css";
 
@@ -69,18 +69,17 @@ class ResultsList extends React.Component {
     localStorage.setItem(SORT_DIRECTION_STORE, e.target.value);
   };
 
-  renderTable = ({ data, loading }) => {
-    const { sortColumn, sortOrder } = this.state;
+  handleTableSort = (sortColumn, direction) =>
+    this.setState({ sortColumn, sortOrder: direction });
 
-    return data.length > 0 ? (
+  renderTable = ({ data }) =>
+    data.length > 0 ? (
       <DataTable
         data={data}
-        sortColumn={sortColumn}
-        sortOrder={sortOrder}
-        theme={this.props.theme}
+        columns={GRQ_DISPLAY_COLUMNS}
+        sortHandler={this.handleTableSort}
       />
     ) : null;
-  };
 
   render() {
     const { componentId, queryParams } = this.props;
@@ -112,7 +111,9 @@ class ResultsList extends React.Component {
             label="Sort By: "
             value={sortColumn}
             onChange={this.handleSortColumn}
-            options={SORT_OPTIONS}
+            options={GRQ_DISPLAY_COLUMNS.filter((d) => d.accessor).map((d) =>
+              d.keyword ? `${d.accessor}.keyword` : d.accessor
+            )}
           />
           <SortDirection
             value={sortOrder}
@@ -142,6 +143,11 @@ class ResultsList extends React.Component {
           )}
           renderItem={tableView ? null : this.resultsListHandler}
           render={tableView ? this.renderTable : null}
+          onError={(e) => {
+            if (e.responses) {
+              alert(JSON.stringify(e.responses));
+            }
+          }}
           sortOptions={sortOptions}
           includeFields={FIELDS ? FIELDS : null}
         />

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -13,8 +13,8 @@ exports.FILTERS = [
     componentId: "resource",
     dataField: "resource",
     title: "Resource",
-    type: "multi",
-    defaultValue: ["job"],
+    type: "single",
+    defaultValue: "job",
   },
   {
     componentId: "status",
@@ -22,6 +22,12 @@ exports.FILTERS = [
     title: "Status",
     type: "single",
     sortBy: "asc",
+  },
+  {
+    componentId: "redelivered",
+    dataField: "job.delivery_info.redelivered",
+    title: "Redelivered",
+    type: "boolean",
   },
   {
     componentId: "tags",
@@ -129,6 +135,7 @@ exports.QUERY_LOGIC = {
     "payload_id",
     "timestamp",
     "endpoint_id",
+    "redelivered",
   ],
 };
 
@@ -157,6 +164,7 @@ exports.FIELDS = [
   "job.job_info.time_start",
   "job.job_info.time_end",
   "job.job_info.metrics.products_staged.id",
+  "job.delivery_info.redelivered",
   "event.traceback",
   "user_tags",
   "dedup_job",

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -5,7 +5,7 @@ exports.FIGARO_DISPLAY_COLUMNS = [
   { Header: "queue", accessor: "job.job_info.job_queue" },
   { Header: "node", accessor: "job.job_info.execute_node" },
   { Header: "timestamp", accessor: "@timestamp", width: 200 },
-  { Header: "duration", accessor: "job.job_info.duration" },
+  { Header: "duration (sec)", accessor: "job.job_info.duration" },
 ];
 
 exports.FILTERS = [

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -4,7 +4,7 @@ exports.FIGARO_DISPLAY_COLUMNS = [
   { Header: "job type", accessor: "job.type" },
   { Header: "queue", accessor: "job.job_info.job_queue" },
   { Header: "node", accessor: "job.job_info.execute_node" },
-  { Header: "timestamp", accessor: "@timestamp" },
+  { Header: "timestamp", accessor: "@timestamp", width: 200 },
   { Header: "duration", accessor: "job.job_info.duration" },
 ];
 
@@ -13,8 +13,8 @@ exports.FILTERS = [
     componentId: "resource",
     dataField: "resource",
     title: "Resource",
-    type: "single",
-    defaultValue: "job",
+    type: "multi",
+    defaultValue: ["job"],
   },
   {
     componentId: "status",
@@ -22,12 +22,6 @@ exports.FILTERS = [
     title: "Status",
     type: "single",
     sortBy: "asc",
-  },
-  {
-    componentId: "redelivered",
-    dataField: "job.delivery_info.redelivered",
-    title: "Redelivered",
-    type: "boolean",
   },
   {
     componentId: "tags",
@@ -114,8 +108,6 @@ exports.FILTERS = [
   },
 ];
 
-exports.SORT_OPTIONS = ["@timestamp"];
-
 // TODO: TRY ADDING .KEYWORD TO COMPONENTID
 exports.QUERY_LOGIC = {
   and: [
@@ -137,7 +129,6 @@ exports.QUERY_LOGIC = {
     "payload_id",
     "timestamp",
     "endpoint_id",
-    "redelivered",
   ],
 };
 
@@ -166,7 +157,6 @@ exports.FIELDS = [
   "job.job_info.time_start",
   "job.job_info.time_end",
   "job.job_info.metrics.products_staged.id",
-  "job.delivery_info.redelivered",
   "event.traceback",
   "user_tags",
   "dedup_job",

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -1,3 +1,5 @@
+// NOTE: add "keyword: true" to the column if the field is sorted by keyword, ex. id.keyword
+// check your Elasticsearch mapping
 exports.FIGARO_DISPLAY_COLUMNS = [
   { Header: "status", accessor: "status" },
   { Header: "job name", accessor: "job.name" },

--- a/src/config/tosca.template.js
+++ b/src/config/tosca.template.js
@@ -145,6 +145,8 @@ exports.QUERY_LOGIC = {
   ],
 };
 
+// NOTE: add "keyword: true" to the column if the field is sorted by keyword, ex. id.keyword
+// check your Elasticsearch mapping
 exports.GRQ_DISPLAY_COLUMNS = [
   { Header: "ID", accessor: "id", width: 400, keyword: true },
   {

--- a/src/config/tosca.template.js
+++ b/src/config/tosca.template.js
@@ -20,17 +20,11 @@ exports.QUERY_SEARCH_COMPONENT_ID = "query_string";
 exports.MAP_COMPONENT_ID = "polygon";
 
 // built in Reactivesearch component id
-exports.DATASET_TYPE_SEARCH_ID = "dataset_type";
-exports.SATELLITE_TYPE_ID = "satellite";
 exports.RESULTS_LIST_COMPONENT_ID = "results";
-exports.DATASET_ID = "dataset";
-exports.START_TIME_ID = "starttime";
-exports.END_TIME_ID = "endtime";
-exports.USER_TAGS = "user_tags";
-exports.DATASET_VERSION = "version";
 
 // fields returned by Elasticsearch (less fields = faster UI)
 exports.FIELDS = [
+  "id",
   "starttime",
   "endtime",
   "location",
@@ -39,18 +33,25 @@ exports.FIELDS = [
   "browse_urls",
   "datasets",
   "metadata.state",
-  "metadata.status",
   "metadata.platform",
   "metadata.sensoroperationalmode",
   "metadata.polarisationmode",
   "metadata.user_tags",
-  "metadata.exists_in_object_store",
   "@timestamp",
+  "bool_value",
+  "dataset",
 ];
 
 exports.GRQ_TABLE_VIEW_DEFAULT = true;
 
 exports.FILTERS = [
+  {
+    componentId: "bool_value",
+    dataField: "bool_value",
+    title: "Bool Value",
+    type: "boolean",
+    size: 1000,
+  },
   {
     componentId: "dataset",
     dataField: "dataset.keyword",
@@ -123,12 +124,6 @@ exports.FILTERS = [
     type: "single",
     size: 1000,
   },
-  {
-    componentId: "exists_in_object_store",
-    dataField: "metadata.exists_in_object_store",
-    title: "Exists In Object Store",
-    type: "boolean",
-  },
 ];
 
 exports.QUERY_LOGIC = {
@@ -144,7 +139,6 @@ exports.QUERY_LOGIC = {
     "continent",
     "state",
     "tags",
-    "exists_in_object_store",
     this.ID_COMPONENT,
     this.MAP_COMPONENT_ID,
     this.QUERY_SEARCH_COMPONENT_ID,
@@ -152,50 +146,30 @@ exports.QUERY_LOGIC = {
 };
 
 exports.GRQ_DISPLAY_COLUMNS = [
+  { Header: "ID", accessor: "id", width: 400, keyword: true },
   {
-    Header: "_id",
-    accessor: "_id",
-    width: 500,
+    Header: "Dataset",
+    accessor: "dataset",
+    className: "keyword",
+    keyword: true,
   },
-  {
-    Header: "ingest_timestamp",
-    accessor: "@timestamp",
-    width: 200,
-  },
-  {
-    Header: "start_time",
-    accessor: "starttime",
-  },
+  { Header: "last_modified", accessor: "@timestamp", width: 200 },
+  { Header: "start_time", accessor: "starttime" },
   { Header: "end_time", accessor: "endtime" },
   {
-    Header: "status",
-    accessor: "metadata.status",
-  },
-  {
-    Header: "direction",
-    accessor: "metadata.direction",
-    width: 100,
-  },
-  {
     id: "browse",
+    sortable: false,
     width: 100,
     resizable: false,
     Cell: (state) =>
-      state.original.urls ? (
+      state.original.browse_urls && state.original.browse_urls.length > 0 ? (
         <a
           target="_blank"
-          href={state.original.urls[0]}
+          href={state.original.browse_urls[0]}
           rel="noopener noreferrer"
         >
           Browse
         </a>
       ) : null,
   },
-];
-
-exports.SORT_OPTIONS = [
-  "@timestamp",
-  "starttime",
-  "endtime",
-  "creation_timestamp",
 ];

--- a/src/config/tosca.template.js
+++ b/src/config/tosca.template.js
@@ -164,10 +164,10 @@ exports.GRQ_DISPLAY_COLUMNS = [
     width: 100,
     resizable: false,
     Cell: (state) =>
-      state.original.browse_urls && state.original.browse_urls.length > 0 ? (
+      state.original.urls && state.original.urls.length > 0 ? (
         <a
           target="_blank"
-          href={state.original.browse_urls[0]}
+          href={state.original.urls[0]}
           rel="noopener noreferrer"
         >
           Browse

--- a/src/config/tosca.template.js
+++ b/src/config/tosca.template.js
@@ -37,21 +37,14 @@ exports.FIELDS = [
   "metadata.sensoroperationalmode",
   "metadata.polarisationmode",
   "metadata.user_tags",
+  "metadata.exists_in_object_store",
   "@timestamp",
-  "bool_value",
   "dataset",
 ];
 
 exports.GRQ_TABLE_VIEW_DEFAULT = true;
 
 exports.FILTERS = [
-  {
-    componentId: "bool_value",
-    dataField: "bool_value",
-    title: "Bool Value",
-    type: "boolean",
-    size: 1000,
-  },
   {
     componentId: "dataset",
     dataField: "dataset.keyword",
@@ -124,6 +117,12 @@ exports.FILTERS = [
     type: "single",
     size: 1000,
   },
+  {
+    componentId: "exists_in_object_store",
+    dataField: "metadata.exists_in_object_store",
+    title: "Exists In Object Store",
+    type: "boolean",
+  },
 ];
 
 exports.QUERY_LOGIC = {
@@ -139,6 +138,7 @@ exports.QUERY_LOGIC = {
     "continent",
     "state",
     "tags",
+    "exists_in_object_store",
     this.ID_COMPONENT,
     this.MAP_COMPONENT_ID,
     this.QUERY_SEARCH_COMPONENT_ID,


### PR DESCRIPTION
changes:
- able to sort elasticsearch results when clicking the table column
  - added a `boolean` field called `keyword` to columns in `GRQ_DISPLAY_COLUMNS` and `FIGARO_DISPLAY_COLUMNS`
  - this value will allow users to sort on fields which require `.keyword`, ex. `id.keyword`
- removed `SORT_OPTIONS`, instead allowing users to sort by all columns displayed in table view
- renamed `@timestamp` to `last_modified`
- fixed bug in tosca's table view where it would display a `browse_url` even though there is no browse url
- removed `FigaroDataTable` component
- add error handling w/ a javascript `alert()` when elasticsearch returns an error when querying

### sorting by `dataset` field `desc`
<img width="750" alt="Screen Shot 2022-10-10 at 10 18 10 AM" src="https://user-images.githubusercontent.com/13371881/194925176-0442323c-3503-4fd0-be92-e2e0c77d5522.png">

### sorting by `dataset` field `asc`
<img width="750" alt="Screen Shot 2022-10-10 at 10 18 18 AM" src="https://user-images.githubusercontent.com/13371881/194925187-1046c96d-47b7-419e-b85f-35529bbc77d6.png">


