### PR TITLE
Improve UI UX and small mobile optimizations

### DIFF
--- a/src/components/Buttons/style.css
+++ b/src/components/Buttons/style.css
@@ -12,7 +12,7 @@
   border-radius: 5px;
   padding: 7px 12px;
   font-size: 12px;
-  height: 30px;
+  min-height: 30px;
   min-width: 75px;
 }
 

--- a/src/components/CustomIdFilter/index.jsx
+++ b/src/components/CustomIdFilter/index.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux"; // redux
+import { connect } from "react-redux";
 import { editCustomFilterId } from "../../redux/actions";
-import { ReactiveComponent } from "@appbaseio/reactivesearch"; // reactivesearch
+import { ReactiveComponent } from "@appbaseio/reactivesearch";
 
 let Handler = class extends React.Component {
   constructor(props) {
@@ -82,7 +82,6 @@ let Handler = class extends React.Component {
   render = () => <></>;
 };
 
-// Redux states and actions
 const mapStateToProps = (state, ownProps) => {
   const { componentId } = ownProps;
   return {

--- a/src/components/FigaroDataViewer/style.css
+++ b/src/components/FigaroDataViewer/style.css
@@ -35,6 +35,12 @@ a:hover {
   text-decoration: none;
 }
 
+@media screen and (max-width: 875px) {
+  .figaro-data-component {
+    margin: 10px 0px;
+  }
+}
+
 .__theme-dark .figaro-data-component {
   background-color: var(--dark-theme-alt);
   color: var(--dark-theme-color);

--- a/src/components/FigaroDataViewer/style.css
+++ b/src/components/FigaroDataViewer/style.css
@@ -35,7 +35,7 @@ a:hover {
   text-decoration: none;
 }
 
-@media screen and (max-width: 875px) {
+@media screen and (max-width: 900px) {
   .figaro-data-component {
     margin: 10px 0px;
   }

--- a/src/components/FigaroResultsList/index.jsx
+++ b/src/components/FigaroResultsList/index.jsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { connect } from "react-redux"; // redux
+import { connect } from "react-redux";
 
-import { ReactiveList } from "@appbaseio/reactivesearch"; // reactivesearch
+import { ReactiveList } from "@appbaseio/reactivesearch";
 import { retrieveData, editCustomFilterId } from "../../redux/actions";
 
 import { FigaroDataViewer } from "../../components/FigaroDataViewer";

--- a/src/components/FigaroResultsList/index.jsx
+++ b/src/components/FigaroResultsList/index.jsx
@@ -93,23 +93,25 @@ class FigaroResultsList extends React.Component {
             checked={tableView}
           />
           <div className="results-display-buffer" />
-          <SortOptions
-            label="Sort By: "
-            value={sortColumn}
-            onChange={this.handleSortColumn}
-            options={FIGARO_DISPLAY_COLUMNS.filter((d) => d.accessor).map((d) =>
-              d.keyword ? `${d.accessor}.keyword` : d.accessor
-            )}
-          />
-          <SortDirection
-            value={sortOrder}
-            onChange={this.handleSortDirection}
-          />
-          <PageSizeOptions
-            label="Page Size: "
-            value={pageSize}
-            onChange={this.handlePageSize}
-          />
+          <div className="sort-wrapper">
+            <SortOptions
+              label="Sort:"
+              value={sortColumn}
+              onChange={this.handleSortColumn}
+              options={FIGARO_DISPLAY_COLUMNS.filter((d) => d.accessor).map(
+                (d) => (d.keyword ? `${d.accessor}.keyword` : d.accessor)
+              )}
+            />
+            <SortDirection
+              value={sortOrder}
+              onChange={this.handleSortDirection}
+            />
+            <PageSizeOptions
+              label="Page Size: "
+              value={pageSize}
+              onChange={this.handlePageSize}
+            />
+          </div>
         </div>
 
         <ReactiveList

--- a/src/components/FigaroResultsList/style.css
+++ b/src/components/FigaroResultsList/style.css
@@ -21,6 +21,16 @@
   padding: 15px;
 }
 
+@media screen and (max-width: 1050px) {
+  .results-display-options {
+    display: block;
+  }
+
+  .sort-wrapper {
+    padding: 7px 0px;
+  }
+}
+
 .__theme-light .figaro-result-stats {
   color: var(--light-theme-color);
 }

--- a/src/components/FigaroResultsList/style.css
+++ b/src/components/FigaroResultsList/style.css
@@ -22,6 +22,7 @@
 }
 
 @media screen and (max-width: 1050px) {
+/* @media screen and (max-width: var(--breakpoint-xl)) { */
   .results-display-options {
     display: block;
   }

--- a/src/components/FigaroResultsList/style.css
+++ b/src/components/FigaroResultsList/style.css
@@ -21,7 +21,7 @@
   padding: 15px;
 }
 
-@media screen and (max-width: 1050px) {
+@media screen and (max-width: 1000px) {
 /* @media screen and (max-width: var(--breakpoint-xl)) { */
   .results-display-options {
     display: block;

--- a/src/components/FigaroResultsList/style.css
+++ b/src/components/FigaroResultsList/style.css
@@ -22,7 +22,6 @@
 }
 
 @media screen and (max-width: 1000px) {
-/* @media screen and (max-width: var(--breakpoint-xl)) { */
   .results-display-options {
     display: block;
   }

--- a/src/components/HeaderBar/style.css
+++ b/src/components/HeaderBar/style.css
@@ -25,7 +25,7 @@
   text-align: center;
   text-decoration: none;
   color: white;
-  padding: 14px 16px;
+  padding: 14px 14px;
 }
 
 .header-bar-title {

--- a/src/components/IdQueryHandler/index.jsx
+++ b/src/components/IdQueryHandler/index.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux"; // redux
+import { connect } from "react-redux";
 import { clickDatasetId } from "../../redux/actions";
-import { ReactiveComponent } from "@appbaseio/reactivesearch"; // reactivesearch
+import { ReactiveComponent } from "@appbaseio/reactivesearch";
 
 var Handler = class extends React.Component {
   constructor(props) {
@@ -60,7 +60,6 @@ var Handler = class extends React.Component {
   render = () => <></>;
 };
 
-// Redux states and actions
 const mapStateToProps = (state) => ({
   _id: state.reactivesearchReducer._id,
 });

--- a/src/components/JobCountsBanner/style.css
+++ b/src/components/JobCountsBanner/style.css
@@ -15,7 +15,7 @@
   border-radius: 5px;
 }
 
-@media screen and (max-width: 875px) {
+@media screen and (max-width: 900px) {
   .figaro-job-count {
     margin: 5px 5px 0px 0px;
   }

--- a/src/components/JobCountsBanner/style.css
+++ b/src/components/JobCountsBanner/style.css
@@ -1,7 +1,7 @@
 @import "../../style/global.css";
 
 .figaro-job-count-banner {
-  margin: 15px 0px 10px 0px;
+  margin: 0px 0px 10px 0px;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -11,8 +11,14 @@
   flex: 0 1 10em;
   text-align: center;
   padding: 20px 0px 20px 0px;
-  margin: 10px 5px 10px 5px;
+  margin: 5px 5px 5px 5px;
   border-radius: 5px;
+}
+
+@media screen and (max-width: 875px) {
+  .figaro-job-count {
+    margin: 5px 5px 0px 0px;
+  }
 }
 
 .job-count {

--- a/src/components/ReactiveMap/index.jsx
+++ b/src/components/ReactiveMap/index.jsx
@@ -2,14 +2,14 @@ import React from "react"; // react imports
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 
-import { connect } from "react-redux"; // redux
+import { connect } from "react-redux";
 import {
   clickDatasetId,
   bboxEdit,
   unclickQueryRegion,
 } from "../../redux/actions";
 
-import { ReactiveComponent } from "@appbaseio/reactivesearch"; // reactivesearch
+import { ReactiveComponent } from "@appbaseio/reactivesearch";
 
 import L from "leaflet"; // lealfet
 import "leaflet-draw";
@@ -132,9 +132,8 @@ let MapComponent = class extends React.Component {
           query,
           value: this.props.value,
         });
-      } else {
-        this.sendEmptyQuery(); // handles onClear (facets)
-      }
+      } else this.sendEmptyQuery(); // handles onClear (facets)
+
       this.setState({ value: this.props.value }); // prevent maximum recursion error
       this.props.bboxEdit(this.props.value);
     }

--- a/src/components/ReactiveMap/style.css
+++ b/src/components/ReactiveMap/style.css
@@ -7,7 +7,7 @@
 }
 
 .leaflet-map-container {
-  padding: 0px 35px;
+  padding: 0px 25px;
   margin-top: 10px;
   margin-left: 10px;
   margin-right: 10px;
@@ -82,6 +82,12 @@
 .id-popup-link:hover {
   cursor: pointer;
   text-decoration: underline;
+}
+
+@media screen and (max-width: 875px) {
+  .leaflet-map-container {
+    padding: 0px;
+  }
 }
 
 .__theme-dark .map-coordinates-textbox {

--- a/src/components/ReactiveMap/style.css
+++ b/src/components/ReactiveMap/style.css
@@ -84,7 +84,7 @@
   text-decoration: underline;
 }
 
-@media screen and (max-width: 875px) {
+@media screen and (max-width: 900px) {
   .leaflet-map-container {
     padding: 0px;
   }

--- a/src/components/SearchQuery/index.jsx
+++ b/src/components/SearchQuery/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ReactiveComponent } from "@appbaseio/reactivesearch"; // reactivesearch
+import { ReactiveComponent } from "@appbaseio/reactivesearch";
 
 import { HelperLink } from "../miscellaneous";
 

--- a/src/components/SearchQuery/index.jsx
+++ b/src/components/SearchQuery/index.jsx
@@ -1,18 +1,23 @@
 import React from "react";
 import { ReactiveComponent } from "@appbaseio/reactivesearch"; // reactivesearch
 
+import { HelperLink } from "../miscellaneous";
+
 import "./style.css";
 
 // wrapper component for ReactiveComponent
 function SearchQuery({ componentId, theme }) {
   return (
-    <ReactiveComponent
-      componentId={componentId}
-      URLParams={true}
-      render={({ setQuery, value }) => (
-        <SearchQueryHandler setQuery={setQuery} value={value} theme={theme} />
-      )}
-    />
+    <div className="search-query">
+      <HelperLink link="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html" />
+      <ReactiveComponent
+        componentId={componentId}
+        URLParams={true}
+        render={({ setQuery, value }) => (
+          <SearchQueryHandler setQuery={setQuery} value={value} theme={theme} />
+        )}
+      />
+    </div>
   );
 }
 

--- a/src/components/SearchQuery/style.css
+++ b/src/components/SearchQuery/style.css
@@ -1,5 +1,11 @@
 @import "../../style/global.css";
 
+.search-query {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+}
+
 .query-input-box {
   height: 30px;
   width: 100%;
@@ -10,9 +16,7 @@
 }
 
 .query-input-form {
-  min-width: 250px;
   flex: 1;
-  margin-right: 20px;
 }
 
 .__theme-dark .query-input-box {

--- a/src/components/SidebarFilters/style.css
+++ b/src/components/SidebarFilters/style.css
@@ -32,6 +32,10 @@
   padding-right: 15px;
 }
 
+.reactivesearch-input > ul > li > label > span > span:first-of-type {
+  word-break: break-all;
+}
+
 .reactivesearch-input > ul > li > label::before {
   width: calc(12px + 1px);
   height: 12px;

--- a/src/components/TableOptions/style.css
+++ b/src/components/TableOptions/style.css
@@ -1,4 +1,3 @@
-/* TOGGLE SLIDER */
 .switch {
   position: relative;
   display: inline-block;
@@ -59,7 +58,6 @@ input:checked + .slider:before {
   transform: translateX(26px);
 }
 
-/* Rounded sliders */
 .slider.round {
   border-radius: 34px;
 }
@@ -68,14 +66,12 @@ input:checked + .slider:before {
   border-radius: 50%;
 }
 
-/* SORT OPTIONS */
 .sort-results-select-wrapper {
-  width: 190px;
   display: inline-block;
 }
 
 .sort-direction-select-wrapper {
-  width: 130px;
+  width: 90px;
   display: inline-block;
 }
 
@@ -83,11 +79,18 @@ input:checked + .slider:before {
 .sort-order-dropdown {
   height: 29px;
   font-size: 14px;
-  width: 120px;
   border-radius: 5px;
   background-color: #ffffff;
   -webkit-border-radius: 5px;
   -moz-border-radius: 5px;
+}
+
+.sort-column-dropdown {
+  width: 120px;
+}
+
+.sort-order-dropdown {
+  width: 75px;
 }
 
 input[name="sort-options"],
@@ -98,7 +101,6 @@ select[name="sort-options"] {
   outline: 1px solid #ffffff !important;
 }
 
-/* PAGE SIZE */
 .results-page-select-wrapper {
   width: 175px;
   display: inline-block;

--- a/src/components/ToscaDataViewer/index.jsx
+++ b/src/components/ToscaDataViewer/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux"; // redux
+import { connect } from "react-redux";
 
 import { Link } from "react-router-dom";
 import ReactJson from "react-json-view";

--- a/src/components/ToscaDataViewer/style.css
+++ b/src/components/ToscaDataViewer/style.css
@@ -40,7 +40,7 @@
   padding: 10px;
 }
 
-@media screen and (max-width: 875px) {
+@media screen and (max-width: 900px) {
   .tosca-data-viewer {
     margin: 10px 0px;
   }

--- a/src/components/ToscaDataViewer/style.css
+++ b/src/components/ToscaDataViewer/style.css
@@ -12,6 +12,7 @@
   font-size: 15px;
   text-decoration: underline;
   cursor: pointer;
+  word-break: break-word;
 }
 
 .tosca-data-viewer a.tosca-id-link:hover {
@@ -37,6 +38,12 @@
   overflow: scroll;
   font-size: 11px;
   padding: 10px;
+}
+
+@media screen and (max-width: 875px) {
+  .tosca-data-viewer {
+    margin: 10px 0px;
+  }
 }
 
 .__theme-dark .tosca-data-viewer {

--- a/src/components/ToscaResultsList/index.jsx
+++ b/src/components/ToscaResultsList/index.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { connect } from "react-redux"; // redux
+import { connect } from "react-redux";
 import { clickDatasetId, retrieveData } from "../../redux/actions";
 
-import { ReactiveList } from "@appbaseio/reactivesearch"; // reactivesearch
+import { ReactiveList } from "@appbaseio/reactivesearch";
 import ToscaDataViewer from "../ToscaDataViewer";
 import DataTable from "../DataTable";
 

--- a/src/components/ToscaResultsList/index.jsx
+++ b/src/components/ToscaResultsList/index.jsx
@@ -112,23 +112,25 @@ class ResultsList extends React.Component {
           />
 
           <div className="results-display-buffer" />
-          <SortOptions
-            label="Sort By: "
-            value={sortColumn}
-            onChange={this.handleSortColumn}
-            options={GRQ_DISPLAY_COLUMNS.filter((d) => d.accessor).map((d) =>
-              d.keyword ? `${d.accessor}.keyword` : d.accessor
-            )}
-          />
-          <SortDirection
-            value={sortOrder}
-            onChange={this.handleSortDirection}
-          />
-          <PageSizeOptions
-            label="Page Size: "
-            value={pageSize}
-            onChange={this.handlePageSize}
-          />
+          <div className="sort-wrapper">
+            <SortOptions
+              label="Sort:"
+              value={sortColumn}
+              onChange={this.handleSortColumn}
+              options={GRQ_DISPLAY_COLUMNS.filter((d) => d.accessor).map((d) =>
+                d.keyword ? `${d.accessor}.keyword` : d.accessor
+              )}
+            />
+            <SortDirection
+              value={sortOrder}
+              onChange={this.handleSortDirection}
+            />
+            <PageSizeOptions
+              label="Page Size: "
+              value={pageSize}
+              onChange={this.handlePageSize}
+            />
+          </div>
         </div>
 
         <ReactiveList

--- a/src/components/UserRulesTagsFilter/index.jsx
+++ b/src/components/UserRulesTagsFilter/index.jsx
@@ -33,9 +33,7 @@ function UserRulesTagsFilter(props) {
     container: (base) => ({
       ...base,
       padding: "0px 15px 0px 15px",
-      flexGrow: 0,
-      flexShrink: 0,
-      flexBasis: "30%",
+      width: 300,
     }),
     control: (base) => ({
       ...base,

--- a/src/components/miscellaneous/index.jsx
+++ b/src/components/miscellaneous/index.jsx
@@ -37,14 +37,6 @@ export function HelperLink(props) {
   );
 }
 
-export function Checkbox(props) {
-  return (
-    <>
-      <input className="miscellaneous-checkbox" type="checkbox" {...props} />
-    </>
-  );
-}
-
 export function LastUpdatedAtBanner({ time }) {
   return time ? (
     <div className="last-updated-banner">

--- a/src/components/miscellaneous/style.css
+++ b/src/components/miscellaneous/style.css
@@ -53,14 +53,6 @@
   margin-right: 10px;
 }
 
-.miscellaneous-checkbox {
-  -ms-transform: scale(1.5); /* IE */
-  -moz-transform: scale(1.5); /* FF */
-  -webkit-transform: scale(1.5); /* Safari and Chrome */
-  -o-transform: scale(1.5); /* Opera */
-  transform: scale(1.5);
-}
-
 .last-updated-banner {
   padding: 10px 0 10px 0;
   font-size: 12px;

--- a/src/components/miscellaneous/style.css
+++ b/src/components/miscellaneous/style.css
@@ -1,11 +1,9 @@
-/* Border */
 .job-param-border {
   border: 1px solid #000000b0;
   margin-top: 35px;
   margin-bottom: 35px;
 }
 
-/* Status Bar */
 .job-submit-status-bar {
   position: fixed;
   left: 0;
@@ -64,7 +62,8 @@
 }
 
 .last-updated-banner {
-  padding: 10px 0 0 0;
+  padding: 10px 0 10px 0;
+  font-size: 12px;
   text-align: right;
 }
 

--- a/src/pages/Figaro/index.jsx
+++ b/src/pages/Figaro/index.jsx
@@ -8,7 +8,6 @@ import SidebarFilters from "../../components/SidebarFilters";
 import SearchQuery from "../../components/SearchQuery";
 import CustomIdFilter from "../../components/CustomIdFilter";
 import FigaroResultsList from "../../components/FigaroResultsList";
-// import { HelperLink } from "../../components/miscellaneous";
 import { ButtonLink, ScrollTop } from "../../components/Buttons";
 
 import { setQuery, editCustomFilterId } from "../../redux/actions";

--- a/src/pages/Figaro/index.jsx
+++ b/src/pages/Figaro/index.jsx
@@ -8,7 +8,7 @@ import SidebarFilters from "../../components/SidebarFilters";
 import SearchQuery from "../../components/SearchQuery";
 import CustomIdFilter from "../../components/CustomIdFilter";
 import FigaroResultsList from "../../components/FigaroResultsList";
-import { HelperLink } from "../../components/miscellaneous";
+// import { HelperLink } from "../../components/miscellaneous";
 import { ButtonLink, ScrollTop } from "../../components/Buttons";
 
 import { setQuery, editCustomFilterId } from "../../redux/actions";
@@ -50,7 +50,7 @@ class Figaro extends React.Component {
     });
 
     const body = e.body.split("\n");
-    let [preference, query] = body;
+    let [_, query] = body;
     query = JSON.parse(query);
 
     let parsedQuery = query.query;
@@ -91,7 +91,6 @@ class Figaro extends React.Component {
               <JobCountsBanner updateCount={this.props.getJobCounts} />
 
               <div className="top-bar-wrapper">
-                <HelperLink link="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html" />
                 <SearchQuery componentId="query_string" theme={classTheme} />
 
                 <div className="button-wrapper">

--- a/src/pages/Figaro/style.css
+++ b/src/pages/Figaro/style.css
@@ -78,8 +78,8 @@ input:focus {
   }
 
   .figaro-sidenav {
-    padding-top: 15px;
     min-width: 240px;
+    padding: 15px 16px 20px 16px;
   }
 
   .top-bar-wrapper {

--- a/src/pages/Figaro/style.css
+++ b/src/pages/Figaro/style.css
@@ -72,7 +72,7 @@ input:focus {
   padding: 0px 5px;
 }
 
-@media screen and (max-width: 875px) {
+@media screen and (max-width: 900px) {
   .figaro-body {
     padding: 0px 12px;
   }

--- a/src/pages/Figaro/style.css
+++ b/src/pages/Figaro/style.css
@@ -9,7 +9,6 @@
 
 .figaro-page-wrapper {
   display: flex;
-  min-width: 1100px;
   height: calc(100vh - 45px);
 }
 
@@ -42,12 +41,6 @@ li.active:hover {
   height: 100%;
 }
 
-@media screen and (max-height: 450px) {
-  .figaro-sidenav {
-    padding-top: 15px;
-  }
-}
-
 input:focus {
   outline: none;
 }
@@ -55,10 +48,7 @@ input:focus {
 .top-bar-wrapper {
   margin: 0 auto;
   display: flex;
-  width: 95%;
   align-items: center;
-  min-width: 500px;
-  margin-top: 20px;
   margin-bottom: 15px;
 }
 
@@ -79,7 +69,26 @@ input:focus {
 }
 
 .figaro-button {
-  padding: 0px 7px;
+  padding: 0px 5px;
+}
+
+@media screen and (max-width: 875px) {
+  .figaro-body {
+    padding: 0px 12px;
+  }
+
+  .figaro-sidenav {
+    padding-top: 15px;
+    min-width: 240px;
+  }
+
+  .top-bar-wrapper {
+    display: block !important;
+  }
+
+  .button-wrapper {
+    margin-top: 10px;
+  }
 }
 
 .__theme-dark.figaro-sidenav {

--- a/src/pages/FigaroOnDemand/style.css
+++ b/src/pages/FigaroOnDemand/style.css
@@ -39,7 +39,7 @@
   padding: 15px;
 }
 
-@media (max-width: 950px) {
+@media (max-width: 900px) {
   .figaro-on-demand {
     display: block;
     overflow: auto;

--- a/src/pages/FigaroOnDemand/style.css
+++ b/src/pages/FigaroOnDemand/style.css
@@ -9,7 +9,6 @@
   height: calc(100vh - 43px);
 }
 
-/* Control the left and right side */
 .on-demand-left,
 .on-demand-right {
   flex: 1;

--- a/src/pages/FigaroRuleEditor/index.jsx
+++ b/src/pages/FigaroRuleEditor/index.jsx
@@ -278,7 +278,6 @@ class FigaroRuleEditor extends React.Component {
   }
 }
 
-// redux state data
 const mapStateToProps = (state) => ({
   darkMode: state.themeReducer.darkMode,
   userRules: state.generalReducer.userRules,

--- a/src/pages/FigaroRuleEditor/style.css
+++ b/src/pages/FigaroRuleEditor/style.css
@@ -37,7 +37,7 @@ body {
   margin: 5px;
 }
 
-@media (max-width: 950px) {
+@media (max-width: 900px) {
   .figaro-user-rule-editor {
     display: block;
     overflow: auto;

--- a/src/pages/FigaroRuleEditor/style.css
+++ b/src/pages/FigaroRuleEditor/style.css
@@ -13,13 +13,11 @@ body {
   height: calc(100vh - 44px);
 }
 
-/* Control the left side */
 .user-rule-editor-left {
   flex: 1;
   overflow: auto;
 }
 
-/* Control the right side */
 .user-rule-editor-right {
   flex: 1;
   overflow: auto;

--- a/src/pages/FigaroUserRules/index.jsx
+++ b/src/pages/FigaroUserRules/index.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
@@ -52,7 +52,7 @@ const FigaroUserRules = class extends React.Component {
     const ruleCount = userRules.length;
 
     return (
-      <div className="figaro-user-rules">
+      <>
         <Helmet>
           <title>Mozart - User Rules</title>
           <meta name="description" content="Helmet application" />
@@ -60,26 +60,28 @@ const FigaroUserRules = class extends React.Component {
         <HeaderBar title="HySDS - User Rules" theme={classTheme} />
 
         <div className="user-rules-body">
-          <div style={{ textAlign: "center" }}>
+          <div className="user-rules-banner">
             <h1>
               Mozart - User Rules {ruleCount > 0 ? `(${ruleCount})` : null}
             </h1>
           </div>
           <div className="user-rules-options-wrapper">
-            <input
-              className="user-rules-global-search"
-              placeholder="Search..."
-              onChange={this.handleRuleSearch}
-              disabled={searchDisabled}
-              value={userRuleSearch}
-            />
+            <div className="user-rules-options">
+              <input
+                className="user-rules-global-search"
+                placeholder="Search..."
+                onChange={this.handleRuleSearch}
+                disabled={searchDisabled}
+                value={userRuleSearch}
+              />
 
-            <UserRulesTagsFilter
-              darkMode={darkMode}
-              tag={userRuleTagFilter}
-              tags={tagFilters}
-              changeUserRuleTagsFilter={changeUserRuleTagsFilter}
-            />
+              <UserRulesTagsFilter
+                darkMode={darkMode}
+                tag={userRuleTagFilter}
+                tags={tagFilters}
+                changeUserRuleTagsFilter={changeUserRuleTagsFilter}
+              />
+            </div>
 
             <div className="user-rules-button-wrapper">
               <ButtonLink href="/figaro/user-rule" label="Create Rule" />
@@ -95,7 +97,7 @@ const FigaroUserRules = class extends React.Component {
             />
           </div>
         </div>
-      </div>
+      </>
     );
   }
 };
@@ -105,7 +107,6 @@ FigaroUserRules.propTypes = {
   userRules: PropTypes.array.isRequired,
 };
 
-// redux state data
 const mapStateToProps = (state) => ({
   darkMode: state.themeReducer.darkMode,
   userRules: state.generalReducer.filteredRules,

--- a/src/pages/FigaroUserRules/style.css
+++ b/src/pages/FigaroUserRules/style.css
@@ -4,9 +4,18 @@
   height: calc(100vh - 47px);
 }
 
+.user-rules-banner {
+  text-align: center;
+}
+
 .user-rules-options-wrapper {
   display: flex;
-  padding: 15px 15px 45px 15px;
+  padding: 15px 15px 35px 15px;
+}
+
+.user-rules-options {
+  display: flex;
+  flex-grow: 1;
 }
 
 .user-rules-button-wrapper {
@@ -21,8 +30,14 @@
   border: solid 1px #dfdfdf;
 }
 
-.figaro-user-rules {
-  min-width: 750px;
+@media screen and (max-width: 750px) {
+  .user-rules-options-wrapper {
+    display: block !important;
+  }
+
+  .user-rules-options {
+    margin-bottom: 10px;
+  }
 }
 
 .__theme-dark .user-rules-options-wrapper input {

--- a/src/pages/Tosca/index.jsx
+++ b/src/pages/Tosca/index.jsx
@@ -169,7 +169,6 @@ Tosca.defaultProps = {
   theme: "__theme-light",
 };
 
-// redux state data
 const mapStateToProps = (state) => ({
   darkMode: state.themeReducer.darkMode,
   data: state.generalReducer.data,

--- a/src/pages/Tosca/index.jsx
+++ b/src/pages/Tosca/index.jsx
@@ -14,7 +14,6 @@ import SearchQuery from "../../components/SearchQuery";
 import { ButtonLink, ScrollTop } from "../../components/Buttons";
 
 import SidebarFilters from "../../components/SidebarFilters";
-import { HelperLink } from "../../components/miscellaneous";
 import HeaderBar, {
   HeaderLink,
   DropdownSources,

--- a/src/pages/Tosca/index.jsx
+++ b/src/pages/Tosca/index.jsx
@@ -112,7 +112,6 @@ class Tosca extends React.Component {
             <div className="tosca-body" ref={this.pageRef}>
               <LastUpdatedAtBanner time={this.state.lastUpdatedAt} />
               <div className="top-bar-wrapper">
-                <HelperLink link="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html" />
                 <SearchQuery
                   componentId={QUERY_SEARCH_COMPONENT_ID}
                   theme={classTheme}

--- a/src/pages/Tosca/style.css
+++ b/src/pages/Tosca/style.css
@@ -80,8 +80,8 @@ input:focus {
   }
 
   .tosca-sidenav {
-    padding-top: 15px;
     min-width: 240px;
+    padding: 15px 16px 20px 16px;
   }
 
   .top-bar-wrapper {

--- a/src/pages/Tosca/style.css
+++ b/src/pages/Tosca/style.css
@@ -74,7 +74,7 @@ input:focus {
   padding: 0px 7px;
 }
 
-@media screen and (max-width: 875px) {
+@media screen and (max-width: 900px) {
   .tosca-body {
     padding: 0px 12px;
   }

--- a/src/pages/Tosca/style.css
+++ b/src/pages/Tosca/style.css
@@ -9,7 +9,6 @@
 
 .tosca-page-wrapper {
   display: flex;
-  min-width: 1100px;
   height: calc(100vh - 45px);
 }
 
@@ -42,12 +41,6 @@ li.active:hover {
   height: 100%;
 }
 
-@media screen and (max-height: 450px) {
-  .tosca-sidenav {
-    padding-top: 15px;
-  }
-}
-
 input:focus {
   outline: none;
 }
@@ -55,9 +48,7 @@ input:focus {
 .top-bar-wrapper {
   margin: 0 auto;
   display: flex;
-  width: 95%;
   align-items: center;
-  min-width: 500px;
   margin-top: 20px;
   margin-bottom: 15px;
 }
@@ -81,6 +72,25 @@ input:focus {
 
 .tosca-button {
   padding: 0px 7px;
+}
+
+@media screen and (max-width: 875px) {
+  .tosca-body {
+    padding: 0px 12px;
+  }
+
+  .tosca-sidenav {
+    padding-top: 15px;
+    min-width: 240px;
+  }
+
+  .top-bar-wrapper {
+    display: block !important;
+  }
+
+  .button-wrapper {
+    margin-top: 10px;
+  }
 }
 
 .__theme-dark.tosca-sidenav {

--- a/src/pages/ToscaOnDemand/index.jsx
+++ b/src/pages/ToscaOnDemand/index.jsx
@@ -136,7 +136,7 @@ class ToscaOnDemand extends React.Component {
     const classTheme = darkMode ? "__theme-dark" : "__theme-light";
 
     return (
-      <div className="tosca-on-demand-page">
+      <>
         <Helmet>
           <title>Tosca - On Demand</title>
           <meta name="description" content="Helmet application" />
@@ -277,7 +277,7 @@ class ToscaOnDemand extends React.Component {
           status="failed"
           reason={this.state.failureReason}
         />
-      </div>
+      </>
     );
   }
 }

--- a/src/pages/ToscaOnDemand/style.css
+++ b/src/pages/ToscaOnDemand/style.css
@@ -9,7 +9,6 @@
   height: calc(100vh - 43px);
 }
 
-/* Control the left and right side */
 .on-demand-left,
 .on-demand-right {
   flex: 1;

--- a/src/pages/ToscaOnDemand/style.css
+++ b/src/pages/ToscaOnDemand/style.css
@@ -1,9 +1,5 @@
 @import "../../style/global.css";
 
-.tosca-on-demand-page {
-  min-width: 650px;
-}
-
 .tosca-on-demand {
   display: flex;
   height: calc(100vh - 43px);
@@ -39,7 +35,7 @@
   padding: 15px;
 }
 
-@media (max-width: 950px) {
+@media (max-width: 900px) {
   .tosca-on-demand {
     display: block;
     overflow: auto;

--- a/src/pages/ToscaRuleEditor/style.css
+++ b/src/pages/ToscaRuleEditor/style.css
@@ -13,13 +13,11 @@ body {
   height: calc(100vh - 44px);
 }
 
-/* Control the left side */
 .user-rule-editor-left {
   flex: 1;
   overflow: auto;
 }
 
-/* Control the right side */
 .user-rule-editor-right {
   flex: 1;
   overflow: auto;

--- a/src/pages/ToscaRuleEditor/style.css
+++ b/src/pages/ToscaRuleEditor/style.css
@@ -37,7 +37,7 @@ body {
   margin: 5px;
 }
 
-@media (max-width: 950px) {
+@media (max-width: 900px) {
   .tosca-user-rule-editor {
     display: block;
     overflow: auto;

--- a/src/pages/ToscaUserRules/index.jsx
+++ b/src/pages/ToscaUserRules/index.jsx
@@ -52,7 +52,7 @@ const ToscaUserRules = class extends React.Component {
     const ruleCount = userRules.length;
 
     return (
-      <div className="tosca-user-rules">
+      <>
         <Helmet>
           <title>Tosca - User Rules</title>
           <meta name="description" content="Helmet application" />
@@ -60,24 +60,26 @@ const ToscaUserRules = class extends React.Component {
         <HeaderBar title="HySDS - User Rules" theme={classTheme} />
 
         <div className="user-rules-body">
-          <div style={{ textAlign: "center" }}>
+          <div className="user-rules-banner">
             <h1>GRQ - User Rules {ruleCount > 0 ? `(${ruleCount})` : null}</h1>
           </div>
           <div className="user-rules-options-wrapper">
-            <input
-              className="user-rules-global-search"
-              placeholder="Search..."
-              onChange={this.handleRuleSearch}
-              disabled={searchDisabled}
-              value={userRuleSearch}
-            />
+            <div className="user-rules-options">
+              <input
+                className="user-rules-global-search"
+                placeholder="Search..."
+                onChange={this.handleRuleSearch}
+                disabled={searchDisabled}
+                value={userRuleSearch}
+              />
 
-            <UserRulesTagsFilter
-              darkMode={darkMode}
-              tag={userRuleTagFilter}
-              tags={tagFilters}
-              changeUserRuleTagsFilter={changeUserRuleTagsFilter}
-            />
+              <UserRulesTagsFilter
+                darkMode={darkMode}
+                tag={userRuleTagFilter}
+                tags={tagFilters}
+                changeUserRuleTagsFilter={changeUserRuleTagsFilter}
+              />
+            </div>
 
             <div className="user-rules-button-wrapper">
               <ButtonLink href="/tosca/user-rule" label="Create Rule" />
@@ -93,7 +95,7 @@ const ToscaUserRules = class extends React.Component {
             />
           </div>
         </div>
-      </div>
+      </>
     );
   }
 };
@@ -103,7 +105,6 @@ ToscaUserRules.propTypes = {
   userRules: PropTypes.array.isRequired,
 };
 
-// redux state data
 const mapStateToProps = (state) => ({
   darkMode: state.themeReducer.darkMode,
   userRules: state.generalReducer.filteredRules,

--- a/src/pages/ToscaUserRules/style.css
+++ b/src/pages/ToscaUserRules/style.css
@@ -4,9 +4,18 @@
   height: calc(100vh - 47px);
 }
 
+.user-rules-banner {
+  text-align: center;
+}
+
 .user-rules-options-wrapper {
   display: flex;
-  padding: 15px 15px 45px 15px;
+  padding: 15px 15px 35px 15px;
+}
+
+.user-rules-options {
+  display: flex;
+  flex-grow: 1;
 }
 
 .user-rules-button-wrapper {
@@ -21,8 +30,14 @@
   border: solid 1px #dfdfdf;
 }
 
-.tosca-user-rules {
-  min-width: 750px;
+@media screen and (max-width: 750px) {
+  .user-rules-options-wrapper {
+    display: block !important;
+  }
+
+  .user-rules-options {
+    margin-bottom: 10px;
+  }
 }
 
 .__theme-dark .user-rules-options-wrapper input {

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -31,6 +31,9 @@
   --offline-color-hover: #101010;
 
   --link-color: #0000ee;
+
+  /* --breakpoint-xl: 1050px; */
+  /* --breakpoint-lg: 900px; */
 }
 
 :export {

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -32,7 +32,7 @@
 
   --link-color: #0000ee;
 
-  /* --breakpoint-xl: 1050px; */
+  /* --breakpoint-xl: 1000px; */
   /* --breakpoint-lg: 900px; */
 }
 


### PR DESCRIPTION
change(s):
- fixed UI/UX behavior in tosca and figaro's main page when in collapsed view
- small mobile optimizations on all pages
  - reduced margin & padding in collapsed view for more compact-ness
  - reduced width of sidebar
- small mobile optimizations on tosca and figaro's on-demand + user rules editor page(s)
- fixed small button text overflow
- removed useless + obvious comments
- fixed `word-break` in tosca data component when ID is too long
- fixed `word-break` in sidebar filters when words are too long
- fixed `UserRulesTags` styling

***TODO:*** consolidate the CSS files for on-demand, rule editors and view rules pages to avoid repeaeted styling

### collapsed checkboxes/radio buttons in filters when the is too long
<img width="290" alt="Screen Shot 2022-10-13 at 3 20 13 PM" src="https://user-images.githubusercontent.com/13371881/196007934-159add96-0c08-4657-8c9e-00cc8807c1a8.png">

### weird behavior in collapsed view and scrolling to the right
<img width="814" alt="Screen Shot 2022-10-15 at 2 27 31 PM" src="https://user-images.githubusercontent.com/13371881/196008215-786324dd-7c89-4a98-8aca-3407244f44ed.png">

### ID spills out the side when too long
<img width="751" alt="Screen Shot 2022-10-15 at 2 33 52 PM" src="https://user-images.githubusercontent.com/13371881/196008461-4176ac18-89e4-4f91-aec2-80bd7777c537.png">

# Improved collapsed view
<img width="822" alt="Screen Shot 2022-10-17 at 11 02 05 AM" src="https://user-images.githubusercontent.com/13371881/196250063-04ca3bb2-e55e-4a9d-8547-4d7d099ef3ff.png">
<img width="792" alt="Screen Shot 2022-10-17 at 11 04 44 AM" src="https://user-images.githubusercontent.com/13371881/196250426-533e1659-958d-407e-8439-cf1bbdebfe36.png">


