### PR TITLE
added indent to traceback in the job-fail's

### DIFF
--- a/src/components/FigaroDataViewer/index.jsx
+++ b/src/components/FigaroDataViewer/index.jsx
@@ -78,10 +78,18 @@ export const FigaroDataViewer = (props) => {
         return (
           <>
             {res.traceback ? (
-              <div className="figaro-code-format">{res.traceback}</div>
+              <div className="figaro-code-format">
+                <pre>
+                  <code>{res.traceback}</code>
+                </pre>
+              </div>
             ) : null}
             {res.event && res.event.traceback ? (
-              <div className="figaro-code-format">{res.event.traceback}</div>
+              <div className="figaro-code-format">
+                <pre>
+                  <code>{res.event.traceback}</code>
+                </pre>
+              </div>
             ) : null}
           </>
         );
@@ -90,7 +98,11 @@ export const FigaroDataViewer = (props) => {
         return (
           <>
             {res.msg_details ? (
-              <div className="figaro-code-format">{res.msg_details}</div>
+              <div className="figaro-code-format">
+                <pre>
+                  <code>{res.msg_details}</code>
+                </pre>
+              </div>
             ) : null}
           </>
         );

--- a/src/components/FigaroDataViewer/style.css
+++ b/src/components/FigaroDataViewer/style.css
@@ -11,8 +11,15 @@
 .figaro-code-format {
   font-family: "Courier New", Courier, monospace;
   font-size: 11px;
-  white-space: pre-line;
-  padding: 5px 0px 10px 0px;
+  padding: 5px 0px 0px 0px;
+}
+
+.figaro-code-format > pre > code {
+  white-space: pre-wrap; /* Since CSS 2.1 */
+  white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+  white-space: -pre-wrap; /* Opera 4-6 */
+  white-space: -o-pre-wrap; /* Opera 7 */
+  word-wrap: break-word; /* Internet Explorer 5.5+ */
 }
 
 a.figaro-id-link {


### PR DESCRIPTION
- wrapping the traceback `div` in a `pre` & `code`

before:
<img width="1249" alt="Screen Shot 2022-12-08 at 12 22 46 PM" src="https://user-images.githubusercontent.com/13371881/206560552-ac96b2b4-95ac-4039-9223-0db4e474230a.png">

after:
<img width="1250" alt="Screen Shot 2022-12-08 at 12 24 40 PM" src="https://user-images.githubusercontent.com/13371881/206560582-d75b8fe0-24f5-464f-98ba-ce7e596b9814.png">
