### PR TITLE
improved multi-select functionality

### DIFF
--- a/src/components/SidebarFilters/index.jsx
+++ b/src/components/SidebarFilters/index.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 
 import { SingleList, DateRange, MultiList } from "@appbaseio/reactivesearch";
@@ -15,13 +15,16 @@ function Filter({
   size,
   queryLogic,
 }) {
-  const _queryLogic =
-    queryLogic && queryLogic.constructor === Object
-      ? Object.entries(queryLogic).reduce(
-          (o, [k, v]) => ({ ...o, [k]: v.filter((d) => d !== componentId) }),
-          {}
-        )
-      : queryLogic;
+  const _queryLogic = useMemo(
+    () =>
+      queryLogic && queryLogic.constructor === Object
+        ? Object.entries(queryLogic).reduce(
+            (o, [k, v]) => ({ ...o, [k]: v.filter((d) => d !== componentId) }),
+            {}
+          )
+        : queryLogic,
+    []
+  );
 
   switch (type) {
     case "multi":

--- a/src/components/SidebarFilters/index.jsx
+++ b/src/components/SidebarFilters/index.jsx
@@ -15,6 +15,14 @@ function Filter({
   size,
   queryLogic,
 }) {
+  const _queryLogic =
+    queryLogic && queryLogic.constructor === Object
+      ? Object.entries(queryLogic).reduce(
+          (o, [k, v]) => ({ ...o, [k]: v.filter((d) => d !== componentId) }),
+          {}
+        )
+      : null;
+
   switch (type) {
     case "multi":
       return (
@@ -27,7 +35,7 @@ function Filter({
           sortBy={sortBy}
           size={size || 1000}
           defaultValue={null || defaultValue}
-          react={queryLogic}
+          react={_queryLogic}
           className="reactivesearch-input reactivesearch-multilist"
         />
       );
@@ -51,7 +59,7 @@ function Filter({
           dataField={dataField}
           title={title}
           URLParams={true}
-          react={queryLogic}
+          react={_queryLogic}
           className="reactivesearch-input"
           transformData={(list) =>
             list
@@ -75,7 +83,7 @@ function Filter({
           sortBy={sortBy}
           size={size || 1000}
           defaultValue={null || defaultValue}
-          react={queryLogic}
+          react={_queryLogic}
           className="reactivesearch-input"
         />
       );
@@ -89,7 +97,11 @@ function SidebarFilters({ filters, queryLogic }) {
 }
 
 SidebarFilters.propTypes = {
+  componentId: PropTypes.string.isRequired,
+  dataField: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
   filters: PropTypes.array.isRequired,
+  queryLogic: PropTypes.object,
 };
 
 SidebarFilters.defaultProps = {

--- a/src/components/SidebarFilters/index.jsx
+++ b/src/components/SidebarFilters/index.jsx
@@ -21,7 +21,7 @@ function Filter({
           (o, [k, v]) => ({ ...o, [k]: v.filter((d) => d !== componentId) }),
           {}
         )
-      : null;
+      : queryLogic;
 
   switch (type) {
     case "multi":


### PR DESCRIPTION
Changes(s):
- now able to select multiple options in a sidebar filter (only for multi list filters)
- added addtl prop type checking in `SidebarFilters`

Example:
Given this sidebar multi select filter for job tags:
<img width="312" alt="Screenshot 2023-07-10 at 11 50 24 AM" src="https://github.com/hysds/hysds_ui/assets/13371881/43d29cbc-5ea7-4508-b202-3b4f58a111e7">

### Before:
When selecting it would reduce the options to 1
<img width="315" alt="Screenshot 2023-07-10 at 11 43 53 AM" src="https://github.com/hysds/hysds_ui/assets/13371881/5586ff2f-8076-4f18-9eac-dcdb27f00eb7">

### After:
Now users can select multiple options
<img width="323" alt="Screenshot 2023-07-10 at 11 43 04 AM" src="https://github.com/hysds/hysds_ui/assets/13371881/83a1b48a-3ce7-48c6-99d9-83eac2dc46a1">
