### PR TITLE
HC-508: Remove "Kibana" from Metrics title in Sources menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/HeaderBar/index.jsx
+++ b/src/components/HeaderBar/index.jsx
@@ -53,7 +53,7 @@ export function DropdownSources() {
           GRQ Rest API
         </a>
         <a href={KIBANA_URL} target="_blank">
-          Metrics (Kibana)
+          Metrics
         </a>
         <a
           href={`${window.location.protocol}//${window.location.hostname}:${RABBIT_MQ_PORT}`}


### PR DESCRIPTION
This updates the title in the Sources menu such that we remove the "Kibana" reference for Metrics since we now have the ability to deploy either OpenSearch or Kibana:

![image](https://github.com/hysds/hysds_ui/assets/42812746/0716ce03-350c-4310-9637-c2b11cc8d68c)
