### PR TITLE
HC-509: Inconsistent query between Tosca/Figaro facet and On-Demand page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/Form/Params/index.jsx
+++ b/src/components/Form/Params/index.jsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 
 import Select from "react-select";
 
+import { parseFacetQuery } from "../../../utils";
+
 import "./style.css";
 
 function Params(props) {

--- a/src/components/SidebarFilters/index.jsx
+++ b/src/components/SidebarFilters/index.jsx
@@ -100,9 +100,6 @@ function SidebarFilters({ filters, queryLogic }) {
 }
 
 SidebarFilters.propTypes = {
-  // componentId: PropTypes.string.isRequired,
-  // dataField: PropTypes.string.isRequired,
-  // title: PropTypes.string.isRequired,
   filters: PropTypes.array.isRequired,
   queryLogic: PropTypes.object,
 };

--- a/src/components/SidebarFilters/index.jsx
+++ b/src/components/SidebarFilters/index.jsx
@@ -100,9 +100,9 @@ function SidebarFilters({ filters, queryLogic }) {
 }
 
 SidebarFilters.propTypes = {
-  componentId: PropTypes.string.isRequired,
-  dataField: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  // componentId: PropTypes.string.isRequired,
+  // dataField: PropTypes.string.isRequired,
+  // title: PropTypes.string.isRequired,
   filters: PropTypes.array.isRequired,
   queryLogic: PropTypes.object,
 };

--- a/src/pages/Figaro/index.jsx
+++ b/src/pages/Figaro/index.jsx
@@ -128,12 +128,6 @@ class Figaro extends React.Component {
                 <CustomIdFilter componentId="_id" dataField="_id" />
               </div>
 
-              <div>
-                <pre style={{ whiteSpace: "pre-wrap" }}>
-                  {JSON.stringify(this.state.query)}
-                </pre>
-              </div>
-
               <FigaroResultsList />
             </div>
             <ScrollTop onClick={() => this.pageRef.current.scrollTo(0, 0)} />

--- a/src/pages/Figaro/index.jsx
+++ b/src/pages/Figaro/index.jsx
@@ -10,7 +10,7 @@ import CustomIdFilter from "../../components/CustomIdFilter";
 import FigaroResultsList from "../../components/FigaroResultsList";
 import { ButtonLink, ScrollTop } from "../../components/Buttons";
 
-import { setQuery, editCustomFilterId } from "../../redux/actions";
+import { editCustomFilterId } from "../../redux/actions";
 import { getJobCounts } from "../../redux/actions/figaro";
 
 import HeaderBar, {
@@ -19,6 +19,7 @@ import HeaderBar, {
 } from "../../components/HeaderBar";
 import { LastUpdatedAtBanner } from "../../components/miscellaneous";
 
+import { parseFacetQuery } from "../../utils";
 import { LOCAL_DEV, MOZART_ES_URL, MOZART_ES_INDICES } from "../../config";
 import { FILTERS, QUERY_LOGIC } from "../../config/figaro";
 
@@ -35,6 +36,7 @@ class Figaro extends React.Component {
 
     this.state = {
       lastUpdatedAt: null,
+      query: null,
     };
   }
 
@@ -48,18 +50,14 @@ class Figaro extends React.Component {
       lastUpdatedAt: `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`,
     });
 
-    const body = e.body.split("\n");
-    let [_, query] = body;
-    query = JSON.parse(query);
-
-    let parsedQuery = query.query;
-    parsedQuery = JSON.stringify(parsedQuery);
-    this.props.setQuery(parsedQuery);
+    const query = parseFacetQuery(e.body, "figaro-results");
+    if (query) this.setState({ query });
     return e;
   };
 
   render() {
-    const { darkMode, query, dataCount } = this.props;
+    const { darkMode, dataCount } = this.props;
+    const { query } = this.state;
     const classTheme = darkMode ? "__theme-dark" : "__theme-light";
 
     return (
@@ -130,6 +128,12 @@ class Figaro extends React.Component {
                 <CustomIdFilter componentId="_id" dataField="_id" />
               </div>
 
+              <div>
+                <pre style={{ whiteSpace: "pre-wrap" }}>
+                  {JSON.stringify(this.state.query)}
+                </pre>
+              </div>
+
               <FigaroResultsList />
             </div>
             <ScrollTop onClick={() => this.pageRef.current.scrollTo(0, 0)} />
@@ -146,12 +150,10 @@ Figaro.defaultProps = {
 
 const mapStateToProps = (state) => ({
   darkMode: state.themeReducer.darkMode,
-  query: state.generalReducer.query,
   dataCount: state.generalReducer.dataCount,
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  setQuery: (query) => dispatch(setQuery(query)),
   getJobCounts: () => dispatch(getJobCounts()),
   editCustomFilterId: (componentId, value) =>
     dispatch(editCustomFilterId(componentId, value)),

--- a/src/pages/Tosca/index.jsx
+++ b/src/pages/Tosca/index.jsx
@@ -145,12 +145,6 @@ class Tosca extends React.Component {
                 <SelectedFilters className="filter-list" />
               </div>
 
-              <div>
-                <pre style={{ whiteSpace: "pre-wrap" }}>
-                  {JSON.stringify(query)}
-                </pre>
-              </div>
-
               <div ref={this.mapRef}>{reactiveMap}</div>
               <ToscaResultsList
                 componentId={RESULTS_LIST_COMPONENT_ID}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -158,6 +158,12 @@ exports.validateUserRule = (props) => {
   return true;
 };
 
+/**
+ *
+ * @param {String} body - the _msearch query body
+ * @param {Stirng} componentId - corresponding component-id for the reactivesearch component
+ * @returns {String} - the corresponding ES query for the displayed results
+ */
 exports.parseFacetQuery = (body, componentId) => {
   const splitBody = body.split("\n");
   const idx = splitBody.findIndex(

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -157,3 +157,16 @@ exports.validateUserRule = (props) => {
     return false;
   return true;
 };
+
+exports.parseFacetQuery = (body, componentId) => {
+  const splitBody = body.split("\n");
+  const idx = splitBody.findIndex(
+    (d) => d === `{"preference":"${componentId}"}`
+  );
+  if (idx === -1) return null;
+  let query = splitBody[idx + 1];
+  query = JSON.parse(query);
+
+  // main query ran to get the data
+  return JSON.stringify(query.query);
+};


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-509

## change(s):
- fixed the bug causing inconsistent queries passed to on-demand
- `query` moved from redux store to in component `state`
- moved query parsing logic to utility function called `parseFacetQuery`
- bump version

## Explanation of bug:
before when clicking a facet and then a second facet, it will grab wrong query in the `_msearch` body
<img width="1194" alt="Screenshot 2024-02-15 at 3 14 22 PM" src="https://github.com/hysds/hysds_ui/assets/13371881/fa2c2fa5-0906-4f2c-bad5-87456e8a9ec5">

the bug is b/c we are grabbing the second entry in the array of ES queries
<img width="1146" alt="Screenshot 2024-02-15 at 3 27 25 PM" src="https://github.com/hysds/hysds_ui/assets/13371881/e03d06e1-66ae-417b-9859-535f2122a050">

instead we find the query which matches the `results` component id and grab the corresponding query
now when clicking 2 facets it will correctly parse the `_msearch` query
<img width="1135" alt="Screenshot 2024-02-15 at 3 16 14 PM" src="https://github.com/hysds/hysds_ui/assets/13371881/546e1ff9-e507-47ac-bead-12f13657ac29">

