### PR TITLE
HC-101

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/run-with-legacy-openssl.sh
+++ b/run-with-legacy-openssl.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Script to run npm commands with legacy OpenSSL provider
+# This fixes the Node.js v17+ OpenSSL compatibility issue with older webpack versions
+
+export NODE_OPTIONS="--openssl-legacy-provider"
+
+# Run the command passed as arguments
+exec "$@"

--- a/src/components/ConfirmationModal/index.jsx
+++ b/src/components/ConfirmationModal/index.jsx
@@ -1,0 +1,83 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Button } from "../Buttons";
+
+import "./style.css";
+
+const ConfirmationModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmText,
+  cancelText,
+  confirmColor,
+  loading,
+}) => {
+  if (!isOpen) return null;
+
+  const handleBackdropClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="confirmation-modal-overlay" onClick={handleBackdropClick}>
+      <div className="confirmation-modal">
+        <div className="confirmation-modal-header">
+          <h3 className="confirmation-modal-title">{title}</h3>
+          <button
+            className="confirmation-modal-close"
+            onClick={onClose}
+            disabled={loading}
+          >
+            ×
+          </button>
+        </div>
+        <div className="confirmation-modal-body">
+          <p className="confirmation-modal-message">{message}</p>
+        </div>
+        <div className="confirmation-modal-footer">
+          <Button
+            size="large"
+            color="fail"
+            label={cancelText || "Cancel"}
+            onClick={onClose}
+            disabled={loading}
+          />
+          <Button
+            size="large"
+            color={confirmColor || "success"}
+            label={confirmText || "Confirm"}
+            onClick={onConfirm}
+            loading={loading}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ConfirmationModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  confirmText: PropTypes.string,
+  cancelText: PropTypes.string,
+  confirmColor: PropTypes.string,
+  loading: PropTypes.bool,
+};
+
+ConfirmationModal.defaultProps = {
+  confirmText: "Confirm",
+  cancelText: "Cancel",
+  confirmColor: "success",
+  loading: false,
+};
+
+export default ConfirmationModal;

--- a/src/components/ConfirmationModal/style.css
+++ b/src/components/ConfirmationModal/style.css
@@ -1,0 +1,135 @@
+@import "../../style/global.css";
+
+.confirmation-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.confirmation-modal {
+  background-color: var(--light-theme-background);
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  max-width: 500px;
+  width: 90%;
+  max-height: 80vh;
+  overflow: hidden;
+}
+
+.__theme-dark .confirmation-modal {
+  background-color: var(--dark-theme-background);
+  border: 1px solid var(--dark-theme-border);
+}
+
+.confirmation-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px 16px 24px;
+  border-bottom: 1px solid var(--light-theme-border);
+}
+
+.__theme-dark .confirmation-modal-header {
+  border-bottom-color: var(--dark-theme-border);
+}
+
+.confirmation-modal-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--light-theme-color);
+}
+
+.__theme-dark .confirmation-modal-title {
+  color: var(--dark-theme-color);
+}
+
+.confirmation-modal-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: var(--light-theme-color);
+  padding: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.confirmation-modal-close:hover {
+  background-color: var(--light-theme-alt);
+}
+
+.__theme-dark .confirmation-modal-close {
+  color: var(--dark-theme-color);
+}
+
+.__theme-dark .confirmation-modal-close:hover {
+  background-color: var(--dark-theme-light);
+}
+
+.confirmation-modal-close:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.confirmation-modal-body {
+  padding: 20px 24px;
+}
+
+.confirmation-modal-message {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--light-theme-color);
+}
+
+.__theme-dark .confirmation-modal-message {
+  color: var(--dark-theme-color);
+}
+
+.confirmation-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 16px 24px 20px 24px;
+  border-top: 1px solid var(--light-theme-border);
+}
+
+.__theme-dark .confirmation-modal-footer {
+  border-top-color: var(--dark-theme-border);
+}
+
+/* Responsive design */
+@media (max-width: 480px) {
+  .confirmation-modal {
+    width: 95%;
+    margin: 20px;
+  }
+  
+  .confirmation-modal-header,
+  .confirmation-modal-body,
+  .confirmation-modal-footer {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+  
+  .confirmation-modal-footer {
+    flex-direction: column;
+  }
+  
+  .confirmation-modal-footer button {
+    width: 100%;
+  }
+}

--- a/src/components/HeaderBar/index.jsx
+++ b/src/components/HeaderBar/index.jsx
@@ -12,6 +12,7 @@ import {
   GRQ_REST_API_V1,
   KIBANA_URL,
   RABBIT_MQ_PORT,
+  VENUE,
 } from "../../config";
 
 import style from "../../style/global.css";
@@ -34,6 +35,16 @@ export function HeaderTitle(props) {
   return (
     <li className="header-bar-title" {...props}>
       <a>{title}</a>
+    </li>
+  );
+}
+
+export function VenueDisplay() {
+  if (!VENUE) return null;
+  
+  return (
+    <li className="header-bar-venue">
+      <span className="venue-text">{VENUE}</span>
     </li>
   );
 }
@@ -88,6 +99,7 @@ function HeaderBar(props) {
           onClick={themeHandler}
         />
         <div className="header-bar-buffer"></div>
+        <VenueDisplay />
       </ul>
     </div>
   );

--- a/src/components/HeaderBar/style.css
+++ b/src/components/HeaderBar/style.css
@@ -53,7 +53,7 @@
   color: white;
   padding: 14px 16px;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 16px;
   background-color: rgba(255, 255, 255, 0.1);
   border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.2);

--- a/src/components/HeaderBar/style.css
+++ b/src/components/HeaderBar/style.css
@@ -42,6 +42,23 @@
   flex: 1;
 }
 
+.header-bar-venue {
+  margin-left: auto;
+  margin-right: 20px;
+}
+
+.venue-text {
+  display: flex;
+  align-items: center;
+  color: white;
+  padding: 14px 16px;
+  font-weight: 500;
+  font-size: 14px;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
 .header-source-title {
   padding-right: 5px;
 }
@@ -105,6 +122,12 @@
 
 .__theme-dark .link-dropdown-content a:hover {
   background-color: var(--dark-theme-light);
+}
+
+.__theme-dark .venue-text {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: var(--dark-theme-color);
 }
 
 .__theme-light .link-dropdown-content {

--- a/src/config/index.template.js
+++ b/src/config/index.template.js
@@ -1,6 +1,9 @@
 // settings are changed if you want to do local development
 exports.LOCAL_DEV = false;
 
+// Venue configuration - displays in the top banner
+exports.VENUE = "some-venue-string";
+
 // GRQ's ES url
 exports.GRQ_ES_URL = "/grq_es";
 exports.GRQ_ES_INDICES = "grq";

--- a/src/config/index.template.js
+++ b/src/config/index.template.js
@@ -2,7 +2,7 @@
 exports.LOCAL_DEV = false;
 
 // Venue configuration - displays in the top banner
-exports.VENUE = "some-venue-string";
+exports.VENUE = "{{ VENUE }}";
 
 // GRQ's ES url
 exports.GRQ_ES_URL = "/grq_es";

--- a/src/pages/FigaroOnDemand/index.jsx
+++ b/src/pages/FigaroOnDemand/index.jsx
@@ -11,6 +11,7 @@ import Dropdown from "../../components/Form/Dropdown";
 
 import { Button } from "../../components/Buttons";
 import HeaderBar from "../../components/HeaderBar";
+import ConfirmationModal from "../../components/ConfirmationModal";
 
 import { connect } from "react-redux";
 import {
@@ -45,6 +46,10 @@ class FigaroOnDemand extends React.Component {
       submitSuccess: 0,
       submitFailed: 0,
       failureReason: "",
+      showConfirmationModal: false,
+      dataCountLoading: false,
+      queryModified: false,
+      lastValidatedQuery: props.query || "",
     };
   }
 
@@ -57,7 +62,109 @@ class FigaroOnDemand extends React.Component {
     }
   }
 
-  checkQueryDataCount = () => this.props.editDataCount(this.props.query);
+  componentDidUpdate(prevProps) {
+    // Track query changes to determine if validation is needed
+    if (prevProps.query !== this.props.query) {
+      this.setState({
+        queryModified: this.props.query !== this.state.lastValidatedQuery,
+      });
+    }
+  }
+
+  checkQueryDataCount = () => {
+    if (!this.props.query || this.props.query.trim() === '') {
+      return;
+    }
+    
+    try {
+      // Validate that the query is valid JSON
+      JSON.parse(this.props.query);
+      this.setState({ dataCountLoading: true });
+      
+      // Create a promise to track when the action completes
+      const dataCountPromise = this.props.editDataCount(this.props.query);
+      
+      // Reset loading state when the promise resolves
+      if (dataCountPromise && typeof dataCountPromise.then === 'function') {
+        dataCountPromise.then(() => {
+          // Mark query as validated on successful data count check
+          this.setState({ 
+            dataCountLoading: false,
+            queryModified: false,
+            lastValidatedQuery: this.props.query,
+          });
+        }).catch(() => {
+          this.setState({ dataCountLoading: false });
+        });
+      } else {
+        // Fallback timeout if the action doesn't return a promise
+        setTimeout(() => {
+          this.setState({ dataCountLoading: false });
+        }, 5000);
+      }
+    } catch (error) {
+      this.setState({ dataCountLoading: false });
+    }
+  };
+
+  handleSubmitClick = () => {
+    this.setState({ showConfirmationModal: true });
+  };
+
+  handleConfirmSubmit = () => {
+    this.setState({ showConfirmationModal: false });
+    this.handleJobSubmit();
+  };
+
+  handleCancelSubmit = () => {
+    this.setState({ showConfirmationModal: false });
+  };
+
+  getConfirmationMessage = () => {
+    const { hysdsio, submissionType, dataCount } = this.props;
+    const jobName = hysdsio || 'job';
+    
+    // Default to iteration mode if submissionType is null (matching UI behavior)
+    const actualSubmissionType = submissionType || 'iteration';
+    
+    if (actualSubmissionType === 'iteration') {
+      return `Are you sure you want to submit ${dataCount} ${jobName} jobs? This will submit one job for each of the ${dataCount} records found. This action cannot be undone.`;
+    } else {
+      return `Are you sure you want to submit an individual ${jobName} job for the ${dataCount} results? This action cannot be undone.`;
+    }
+  };
+
+  isFormSubmissionDisabled = () => {
+    const { queryModified } = this.state;
+    const { dataCount } = this.props;
+    
+    // Disable if query has been modified since last validation
+    if (queryModified) {
+      return true;
+    }
+    
+    // Disable if no data count or data count is 0
+    if (!dataCount || dataCount === 0) {
+      return true;
+    }
+    
+    return false;
+  };
+
+  getValidationMessage = () => {
+    const { queryModified } = this.state;
+    const { dataCount } = this.props;
+    
+    if (queryModified) {
+      return "Query has been modified. Please click 'Data Count Check' to validate the search results.";
+    }
+    
+    if (!dataCount || dataCount === 0) {
+      return "No results found for the current query. Please modify your query and try again.";
+    }
+    
+    return null;
+  };
 
   handleJobSubmit = () => {
     let { paramsList, params } = this.props;
@@ -100,7 +207,6 @@ class FigaroOnDemand extends React.Component {
     fetch(jobSubmitUrl, { method: "POST", headers, body: JSON.stringify(data) })
       .then((res) => res.json())
       .then((data) => {
-        console.log(data);
         if (!data.success) {
           this.setState({ submitInProgress: 0, submitFailed: 1 });
           setTimeout(() => this.setState({ submitFailed: 0 }), 3000);
@@ -110,7 +216,6 @@ class FigaroOnDemand extends React.Component {
         }
       })
       .catch((err) => {
-        console.error(err);
         this.setState({ submitInProgress: 0, submitFailed: 1 });
         setTimeout(() => this.setState({ submitFailed: 0 }), 3000);
       });
@@ -119,7 +224,7 @@ class FigaroOnDemand extends React.Component {
   render() {
     const { darkMode, query, paramsList, params, hysdsio, submissionType } =
       this.props;
-    const { submitInProgress, submitSuccess, submitFailed } = this.state;
+    const { submitInProgress, submitSuccess, submitFailed, showConfirmationModal, dataCountLoading } = this.state;
 
     const hysdsioLabel = paramsList.length > 0 ? <h2>{hysdsio}</h2> : null;
 
@@ -132,6 +237,8 @@ class FigaroOnDemand extends React.Component {
     ) : null;
 
     const validSubmission = validateSubmission(this.props);
+    const isFormDisabled = this.isFormSubmissionDisabled();
+    const validationMessage = this.getValidationMessage();
 
     const classTheme = darkMode ? "__theme-dark" : "__theme-light";
 
@@ -155,6 +262,11 @@ class FigaroOnDemand extends React.Component {
                 <div className="data-count-header">
                   Total Records: {this.props.dataCount || "N/A"}
                 </div>
+                {validationMessage && (
+                  <div className="validation-message">
+                    <p>{validationMessage}</p>
+                  </div>
+                )}
 
                 <Input
                   label="Tag"
@@ -243,9 +355,9 @@ class FigaroOnDemand extends React.Component {
                     <Button
                       size="large"
                       label={"Submit"}
-                      onClick={this.handleJobSubmit}
+                      onClick={this.handleSubmitClick}
                       loading={submitInProgress}
-                      disabled={!validSubmission || submitInProgress}
+                      disabled={!validSubmission || submitInProgress || isFormDisabled}
                     />
                   </div>
                   <div className="tosca-on-demand-button">
@@ -254,6 +366,8 @@ class FigaroOnDemand extends React.Component {
                       color="success"
                       label="Data Count Check"
                       onClick={this.checkQueryDataCount}
+                      loading={dataCountLoading}
+                      disabled={dataCountLoading}
                     />
                   </div>
                   <div className="tosca-on-demand-button">
@@ -276,6 +390,17 @@ class FigaroOnDemand extends React.Component {
           visible={submitFailed}
           status="failed"
           reason={this.state.failureReason}
+        />
+        <ConfirmationModal
+          isOpen={showConfirmationModal}
+          onClose={this.handleCancelSubmit}
+          onConfirm={this.handleConfirmSubmit}
+          title="Confirm Job Submission"
+          message={this.getConfirmationMessage()}
+          confirmText="Submit Job"
+          cancelText="Cancel"
+          confirmColor="success"
+          loading={submitInProgress}
         />
       </div>
     );

--- a/src/pages/FigaroOnDemand/index.jsx
+++ b/src/pages/FigaroOnDemand/index.jsx
@@ -79,19 +79,23 @@ class FigaroOnDemand extends React.Component {
     try {
       // Validate that the query is valid JSON
       JSON.parse(this.props.query);
+      
+      // Capture the query at the start of validation to prevent race conditions
+      const queryBeingValidated = this.props.query;
       this.setState({ dataCountLoading: true });
       
       // Create a promise to track when the action completes
-      const dataCountPromise = this.props.editDataCount(this.props.query);
+      const dataCountPromise = this.props.editDataCount(queryBeingValidated);
       
       // Reset loading state when the promise resolves
       if (dataCountPromise && typeof dataCountPromise.then === 'function') {
         dataCountPromise.then(() => {
           // Mark query as validated on successful data count check
+          // Use the captured query value, not the current props.query
           this.setState({ 
             dataCountLoading: false,
             queryModified: false,
-            lastValidatedQuery: this.props.query,
+            lastValidatedQuery: queryBeingValidated,
           });
         }).catch(() => {
           this.setState({ dataCountLoading: false });

--- a/src/pages/FigaroOnDemand/index.jsx
+++ b/src/pages/FigaroOnDemand/index.jsx
@@ -25,6 +25,7 @@ import {
   editTimeLimit,
   editDiskUsage,
   editDedup,
+  syncUrlParams,
 } from "../../redux/actions";
 import {
   getOnDemandJobs,
@@ -60,6 +61,9 @@ class FigaroOnDemand extends React.Component {
       this.props.getQueueList(jobSpec);
       this.props.getParamsList(jobSpec);
     }
+    
+    // Sync URL parameters with Redux store
+    this.props.syncUrlParams();
   }
 
   componentDidUpdate(prevProps) {
@@ -438,6 +442,7 @@ const mapDispatchToProps = (dispatch) => ({
   getQueueList: (jobSpec) => dispatch(getQueueList(jobSpec)),
   getParamsList: (jobSpec) => dispatch(getParamsList(jobSpec)),
   editDataCount: (query) => dispatch(editDataCount(query)),
+  syncUrlParams: () => dispatch(syncUrlParams()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(FigaroOnDemand);

--- a/src/pages/FigaroOnDemand/style.css
+++ b/src/pages/FigaroOnDemand/style.css
@@ -39,6 +39,28 @@
   padding: 15px;
 }
 
+.validation-message {
+  padding: 10px 15px;
+  margin: 10px 0;
+  border-radius: 6px;
+  background-color: #fff3cd;
+  border: 1px solid #ffeaa7;
+  color: #856404;
+  font-size: 14px;
+  text-align: center;
+}
+
+.validation-message p {
+  margin: 0;
+  font-weight: 500;
+}
+
+.__theme-dark .validation-message {
+  background-color: #2c3e50;
+  border-color: #f39c12;
+  color: #f39c12;
+}
+
 @media (max-width: 900px) {
   .figaro-on-demand {
     display: block;

--- a/src/pages/ToscaOnDemand/index.jsx
+++ b/src/pages/ToscaOnDemand/index.jsx
@@ -84,19 +84,23 @@ class ToscaOnDemand extends React.Component {
     try {
       // Validate that the query is valid JSON
       JSON.parse(this.props.query);
+      
+      // Capture the query at the start of validation to prevent race conditions
+      const queryBeingValidated = this.props.query;
       this.setState({ dataCountLoading: true });
       
       // Create a promise to track when the action completes
-      const dataCountPromise = this.props.editDataCount(this.props.query);
+      const dataCountPromise = this.props.editDataCount(queryBeingValidated);
       
       // Reset loading state when the promise resolves
       if (dataCountPromise && typeof dataCountPromise.then === 'function') {
         dataCountPromise.then(() => {
           // Mark query as validated on successful data count check
+          // Use the captured query value, not the current props.query
           this.setState({ 
             dataCountLoading: false,
             queryModified: false,
-            lastValidatedQuery: this.props.query,
+            lastValidatedQuery: queryBeingValidated,
           });
         }).catch(() => {
           this.setState({ dataCountLoading: false });

--- a/src/pages/ToscaOnDemand/index.jsx
+++ b/src/pages/ToscaOnDemand/index.jsx
@@ -11,6 +11,7 @@ import Dropdown from "../../components/Form/Dropdown";
 
 import { Button } from "../../components/Buttons";
 import HeaderBar from "../../components/HeaderBar";
+import ConfirmationModal from "../../components/ConfirmationModal";
 
 import { connect } from "react-redux";
 import {
@@ -24,6 +25,7 @@ import {
   editTimeLimit,
   editDiskUsage,
   editDedup,
+  syncUrlParams,
 } from "../../redux/actions";
 import {
   getOnDemandJobs,
@@ -45,8 +47,13 @@ class ToscaOnDemand extends React.Component {
       submitSuccess: 0,
       submitFailed: 0,
       failureReason: "",
+      showConfirmationModal: false,
+      dataCountLoading: false,
+      queryModified: false,
+      lastValidatedQuery: props.query || "",
     };
   }
+
 
   componentDidMount() {
     const { jobSpec } = this.props;
@@ -55,9 +62,114 @@ class ToscaOnDemand extends React.Component {
       this.props.getQueueList(jobSpec);
       this.props.getParamsList(jobSpec);
     }
+    
+    // Sync URL parameters with Redux store
+    this.props.syncUrlParams();
   }
 
-  checkQueryDataCount = () => this.props.editDataCount(this.props.query);
+  componentDidUpdate(prevProps) {
+    // Track query changes to determine if validation is needed
+    if (prevProps.query !== this.props.query) {
+      this.setState({
+        queryModified: this.props.query !== this.state.lastValidatedQuery,
+      });
+    }
+  }
+
+  checkQueryDataCount = () => {
+    if (!this.props.query || this.props.query.trim() === '') {
+      return;
+    }
+    
+    try {
+      // Validate that the query is valid JSON
+      JSON.parse(this.props.query);
+      this.setState({ dataCountLoading: true });
+      
+      // Create a promise to track when the action completes
+      const dataCountPromise = this.props.editDataCount(this.props.query);
+      
+      // Reset loading state when the promise resolves
+      if (dataCountPromise && typeof dataCountPromise.then === 'function') {
+        dataCountPromise.then(() => {
+          // Mark query as validated on successful data count check
+          this.setState({ 
+            dataCountLoading: false,
+            queryModified: false,
+            lastValidatedQuery: this.props.query,
+          });
+        }).catch(() => {
+          this.setState({ dataCountLoading: false });
+        });
+      } else {
+        // Fallback timeout if the action doesn't return a promise
+        setTimeout(() => {
+          this.setState({ dataCountLoading: false });
+        }, 5000);
+      }
+    } catch (error) {
+      this.setState({ dataCountLoading: false });
+    }
+  };
+
+  handleSubmitClick = () => {
+    this.setState({ showConfirmationModal: true });
+  };
+
+  handleConfirmSubmit = () => {
+    this.setState({ showConfirmationModal: false });
+    this.handleJobSubmit();
+  };
+
+  handleCancelSubmit = () => {
+    this.setState({ showConfirmationModal: false });
+  };
+
+  getConfirmationMessage = () => {
+    const { hysdsio, submissionType, dataCount } = this.props;
+    const jobName = hysdsio || 'job';
+    
+    // Default to iteration mode if submissionType is null (matching UI behavior)
+    const actualSubmissionType = submissionType || 'iteration';
+    
+    if (actualSubmissionType === 'iteration') {
+      return `Are you sure you want to submit ${dataCount} ${jobName} jobs? This will submit one job for each of the ${dataCount} records found. This action cannot be undone.`;
+    } else {
+      return `Are you sure you want to submit an individual ${jobName} job for the ${dataCount} results? This action cannot be undone.`;
+    }
+  };
+
+  isFormSubmissionDisabled = () => {
+    const { queryModified } = this.state;
+    const { dataCount } = this.props;
+    
+    // Disable if query has been modified since last validation
+    if (queryModified) {
+      return true;
+    }
+    
+    // Disable if no data count or data count is 0
+    if (!dataCount || dataCount === 0) {
+      return true;
+    }
+    
+    return false;
+  };
+
+  getValidationMessage = () => {
+    const { queryModified } = this.state;
+    const { dataCount } = this.props;
+    
+    if (queryModified) {
+      return "Query has been modified. Please click 'Data Count Check' to validate the search results.";
+    }
+    
+    if (!dataCount || dataCount === 0) {
+      return "No results found for the current query. Please modify your query and try again.";
+    }
+    
+    return null;
+  };
 
   handleJobSubmit = () => {
     let { paramsList, params } = this.props;
@@ -100,7 +212,6 @@ class ToscaOnDemand extends React.Component {
     fetch(jobSubmitUrl, { method: "POST", headers, body: JSON.stringify(data) })
       .then((res) => res.json())
       .then((data) => {
-        console.log(data);
         if (!data.success) {
           this.setState({ submitInProgress: 0, submitFailed: 1 });
           setTimeout(() => this.setState({ submitFailed: 0 }), 3000);
@@ -110,7 +221,6 @@ class ToscaOnDemand extends React.Component {
         }
       })
       .catch((err) => {
-        console.error(err);
         this.setState({ submitInProgress: 0, submitFailed: 1 });
         setTimeout(() => this.setState({ submitFailed: 0 }), 3000);
       });
@@ -119,7 +229,7 @@ class ToscaOnDemand extends React.Component {
   render() {
     const { darkMode, query, paramsList, params, hysdsio, submissionType } =
       this.props;
-    const { submitInProgress, submitSuccess, submitFailed } = this.state;
+    const { submitInProgress, submitSuccess, submitFailed, showConfirmationModal, dataCountLoading } = this.state;
 
     const hysdsioLabel = paramsList.length > 0 ? <h2>{hysdsio}</h2> : null;
 
@@ -132,6 +242,8 @@ class ToscaOnDemand extends React.Component {
     ) : null;
 
     const validSubmission = validateSubmission(this.props);
+    const isFormDisabled = this.isFormSubmissionDisabled();
+    const validationMessage = this.getValidationMessage();
 
     const classTheme = darkMode ? "__theme-dark" : "__theme-light";
 
@@ -155,6 +267,11 @@ class ToscaOnDemand extends React.Component {
                 <div className="data-count-header">
                   Total Records: {this.props.dataCount || "N/A"}
                 </div>
+                {validationMessage && (
+                  <div className="validation-message">
+                    <p>{validationMessage}</p>
+                  </div>
+                )}
 
                 <Input
                   label="Tag"
@@ -243,9 +360,9 @@ class ToscaOnDemand extends React.Component {
                     <Button
                       size="large"
                       label={"Submit"}
-                      onClick={this.handleJobSubmit}
+                      onClick={this.handleSubmitClick}
                       loading={submitInProgress}
-                      disabled={!validSubmission || submitInProgress}
+                      disabled={!validSubmission || submitInProgress || isFormDisabled}
                     />
                   </div>
                   <div className="tosca-on-demand-button">
@@ -254,6 +371,8 @@ class ToscaOnDemand extends React.Component {
                       color="success"
                       label="Data Count Check"
                       onClick={this.checkQueryDataCount}
+                      loading={dataCountLoading}
+                      disabled={dataCountLoading}
                     />
                   </div>
                   <div className="tosca-on-demand-button">
@@ -276,6 +395,17 @@ class ToscaOnDemand extends React.Component {
           visible={submitFailed}
           status="failed"
           reason={this.state.failureReason}
+        />
+        <ConfirmationModal
+          isOpen={showConfirmationModal}
+          onClose={this.handleCancelSubmit}
+          onConfirm={this.handleConfirmSubmit}
+          title="Confirm Job Submission"
+          message={this.getConfirmationMessage()}
+          confirmText="Submit Job"
+          cancelText="Cancel"
+          confirmColor="success"
+          loading={submitInProgress}
         />
       </>
     );
@@ -309,6 +439,7 @@ const mapDispatchToProps = (dispatch) => ({
   getQueueList: (jobSpec) => dispatch(getQueueList(jobSpec)),
   getParamsList: (jobSpec) => dispatch(getParamsList(jobSpec)),
   editDataCount: (query) => dispatch(editDataCount(query)),
+  syncUrlParams: () => dispatch(syncUrlParams()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ToscaOnDemand);

--- a/src/pages/ToscaOnDemand/style.css
+++ b/src/pages/ToscaOnDemand/style.css
@@ -31,8 +31,38 @@
 }
 
 .data-count-header {
-  font-size: 25px;
+  font-size: 20px;
+  font-weight: bold;
   padding: 15px;
+  background-color: #f0f8ff;
+  border: 2px solid #4a90e2;
+  border-radius: 8px;
+  margin: 10px 0;
+  color: #2c3e50;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.validation-message {
+  padding: 10px 15px;
+  margin: 10px 0;
+  border-radius: 6px;
+  background-color: #fff3cd;
+  border: 1px solid #ffeaa7;
+  color: #856404;
+  font-size: 14px;
+  text-align: center;
+}
+
+.validation-message p {
+  margin: 0;
+  font-weight: 500;
+}
+
+.__theme-dark .validation-message {
+  background-color: #2c3e50;
+  border-color: #f39c12;
+  color: #f39c12;
 }
 
 @media (max-width: 900px) {
@@ -63,6 +93,12 @@
 
 .__theme-dark hr {
   border-color: var(--dark-theme-color);
+}
+
+.__theme-dark .data-count-header {
+  background-color: #2c3e50;
+  border-color: #3498db;
+  color: #ecf0f1;
 }
 
 .__theme-dark .on-demand-submission-type {

--- a/src/redux/actions/figaro/index.js
+++ b/src/redux/actions/figaro/index.js
@@ -93,6 +93,13 @@ export const getParamsList = (jobSpec) => (dispatch) => {
 export const editDataCount = (query) => (dispatch) => {
   const ES_QUERY_DATA_COUNT_ENDPOINT = `${MOZART_ES_URL}/${MOZART_ES_INDICES}/_count`;
 
+  // Early validation
+  if (!query || query.trim() === '') {
+    editUrlDataCount(null);
+    dispatch({ type: EDIT_DATA_COUNT, payload: null });
+    return Promise.resolve();
+  }
+
   try {
     let parsedQuery = { query: JSON.parse(query) };
     const headers = {
@@ -101,8 +108,13 @@ export const editDataCount = (query) => (dispatch) => {
       body: JSON.stringify(parsedQuery),
     };
 
-    fetch(ES_QUERY_DATA_COUNT_ENDPOINT, headers)
-      .then((res) => res.json())
+    return fetch(ES_QUERY_DATA_COUNT_ENDPOINT, headers)
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP error! status: ${res.status}`);
+        }
+        return res.json();
+      })
       .then((data) => {
         if (data.error) {
           editUrlDataCount(null);
@@ -111,10 +123,15 @@ export const editDataCount = (query) => (dispatch) => {
           editUrlDataCount(data.count);
           dispatch({ type: EDIT_DATA_COUNT, payload: data.count });
         }
+      })
+      .catch((err) => {
+        editUrlDataCount(null);
+        dispatch({ type: EDIT_DATA_COUNT, payload: null });
       });
   } catch (err) {
     editUrlDataCount(null);
     dispatch({ type: EDIT_DATA_COUNT, payload: null });
+    return Promise.resolve();
   }
 };
 

--- a/src/redux/actions/figaro/index.js
+++ b/src/redux/actions/figaro/index.js
@@ -127,11 +127,12 @@ export const editDataCount = (query) => (dispatch) => {
       .catch((err) => {
         editUrlDataCount(null);
         dispatch({ type: EDIT_DATA_COUNT, payload: null });
+        return Promise.reject(err);
       });
   } catch (err) {
     editUrlDataCount(null);
     dispatch({ type: EDIT_DATA_COUNT, payload: null });
-    return Promise.resolve();
+    return Promise.reject(err);
   }
 };
 

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -24,6 +24,7 @@ import {
   EDIT_CUSTOM_FILTER_ID,
   CLEAR_REDUX_STORE,
   CHANGE_USER_RULE_TAG,
+  EDIT_DATA_COUNT,
 } from "../constants.js";
 
 export const syncUrlParams = () => (dispatch) => {
@@ -33,7 +34,7 @@ export const syncUrlParams = () => (dispatch) => {
   if (total) {
     const parsed = parseInt(total, 10);
     if (!isNaN(parsed)) {
-      dispatch({ type: 'EDIT_DATA_COUNT', payload: parsed });
+      dispatch({ type: EDIT_DATA_COUNT, payload: parsed });
     }
   }
 };

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -26,6 +26,18 @@ import {
   CHANGE_USER_RULE_TAG,
 } from "../constants.js";
 
+export const syncUrlParams = () => (dispatch) => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const total = urlParams.get("total");
+  
+  if (total) {
+    const parsed = parseInt(total, 10);
+    if (!isNaN(parsed)) {
+      dispatch({ type: 'EDIT_DATA_COUNT', payload: parsed });
+    }
+  }
+};
+
 import {
   constructUrl,
   clearUrlJobParams,

--- a/src/redux/actions/tosca/index.js
+++ b/src/redux/actions/tosca/index.js
@@ -27,6 +27,13 @@ import {
 export const editDataCount = (query) => (dispatch) => {
   const ES_QUERY_DATA_COUNT_ENDPOINT = `${GRQ_ES_URL}/${GRQ_ES_INDICES}/_count`;
 
+  // Early validation
+  if (!query || query.trim() === '') {
+    editUrlDataCount(null);
+    dispatch({ type: EDIT_DATA_COUNT, payload: null });
+    return Promise.resolve();
+  }
+
   try {
     let parsedQuery = { query: JSON.parse(query) };
     const headers = {
@@ -35,8 +42,13 @@ export const editDataCount = (query) => (dispatch) => {
       body: JSON.stringify(parsedQuery),
     };
 
-    fetch(ES_QUERY_DATA_COUNT_ENDPOINT, headers)
-      .then((res) => res.json())
+    return fetch(ES_QUERY_DATA_COUNT_ENDPOINT, headers)
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP error! status: ${res.status}`);
+        }
+        return res.json();
+      })
       .then((data) => {
         if (data.error) {
           editUrlDataCount(null);
@@ -45,10 +57,15 @@ export const editDataCount = (query) => (dispatch) => {
           editUrlDataCount(data.count);
           dispatch({ type: EDIT_DATA_COUNT, payload: data.count });
         }
+      })
+      .catch((err) => {
+        editUrlDataCount(null);
+        dispatch({ type: EDIT_DATA_COUNT, payload: null });
       });
   } catch (err) {
     editUrlDataCount(null);
     dispatch({ type: EDIT_DATA_COUNT, payload: null });
+    return Promise.resolve();
   }
 };
 

--- a/src/redux/actions/tosca/index.js
+++ b/src/redux/actions/tosca/index.js
@@ -61,11 +61,12 @@ export const editDataCount = (query) => (dispatch) => {
       .catch((err) => {
         editUrlDataCount(null);
         dispatch({ type: EDIT_DATA_COUNT, payload: null });
+        return Promise.reject(err);
       });
   } catch (err) {
     editUrlDataCount(null);
     dispatch({ type: EDIT_DATA_COUNT, payload: null });
-    return Promise.resolve();
+    return Promise.reject(err);
   }
 };
 

--- a/src/redux/reducers/generalReducer.js
+++ b/src/redux/reducers/generalReducer.js
@@ -50,7 +50,11 @@ let defaultUrlJobParams = extractJobParams(urlParams);
 const initialState = {
   // main page
   data: [],
-  dataCount: urlParams.get("total") || 0,
+  dataCount: (() => {
+    const total = urlParams.get("total");
+    const parsed = total ? parseInt(total, 10) : 0;
+    return isNaN(parsed) ? 0 : parsed;
+  })(),
   jobCounts: {},
 
   // form data


### PR DESCRIPTION
# HC-101: Add confirmation modal prior to on-demand job submission

## Overview
This PR implements significant improvements to the HySDS UI on-demand job submission workflow, including confirmation modals and validation.
Additionally, per OPERA request, venue identification in the tophat banner was implemented. Procedure for update HySDS UI on a deployed cluster can be found at https://hysds-core.atlassian.net/wiki/spaces/HYS/pages/3142483984/How+to+upgrade+HySDS+UI.

## 🚀 Key Features

### 1. Confirmation Modal System
- **New Component**: `ConfirmationModal` - Reusable modal component for user confirmations
- **Smart Messaging**: Dynamic confirmation messages based on submission type (individual vs iteration)
- **Job Count Integration**: Shows exact number of jobs that will be submitted based on data count

### 2. Enhanced Query Validation
- **Real-time Validation**: Form submission disabled when query is modified
- **Data Count Verification**: Users must click "Data Count Check" after query changes
- **Visual Feedback**: Clear validation messages guide users through the process
- **Error Prevention**: Prevents submission of invalid queries or empty results

### 3. Venue Configuration & Display
- **Configurable Venue**: New `VENUE` configuration option in `index.template.js`
- **Template Interpolation**: Supports `{{ VENUE }}` placeholder for deployment automation
- **Top Banner Display**: Venue string appears prominently in the header

### 4. Improved Data Count Check
- **Loading States**: Visual feedback during data count operations
- **Promise Handling**: Proper async/await implementation for better UX
- **Error Handling**: Robust error handling with graceful fallbacks
- **URL Synchronization**: Data count automatically updates URL parameters

## 📁 Files Changed

### New Files
- `src/components/ConfirmationModal/index.jsx` - Reusable confirmation modal component
- `src/components/ConfirmationModal/style.css` - Modal styling with theme support
- `run-with-legacy-openssl.sh` - Helper script for Node.js compatibility

### Modified Files
- `src/pages/FigaroOnDemand/index.jsx` - Enhanced with confirmation modal and validation
- `src/pages/ToscaOnDemand/index.jsx` - Enhanced with confirmation modal and validation
- `src/components/HeaderBar/index.jsx` - Added venue display component
- `src/components/HeaderBar/style.css` - Venue display styling
- `src/config/index.template.js` - Added venue configuration
- `src/redux/actions/figaro/index.js` - Improved data count handling
- `src/redux/actions/tosca/index.js` - Improved data count handling
- `src/redux/actions/index.js` - Added URL parameter synchronization
- `src/redux/reducers/generalReducer.js` - Enhanced data count parsing

## 🎯 User Experience Improvements

### Before
- Jobs submitted immediately without confirmation
- No validation for modified queries
- No indication of venue/environment
- Data count check had inconsistent behavior

### After
- **Confirmation Required**: Users must confirm before submitting jobs
- **Smart Validation**: Form disabled until query is validated
- **Clear Feedback**: Validation messages guide users
- **Venue Awareness**: Users always know which environment they're using
- **Reliable Data Count**: Consistent behavior with loading states

## 🔧 Technical Details

### Confirmation Modal Messages
- **Individual Mode**: "Are you sure you want to submit an individual [job_name] job for the [data_count] results? This action cannot be undone."
- **Iteration Mode**: "Are you sure you want to submit [data_count] [job_name] jobs? This will submit one job for each of the [data_count] records found. This action cannot be undone."

### Validation Logic
- Form submission disabled when:
  - Query has been modified since last validation
  - Data count is 0 or null
  - Data count check is in progress

### Venue Configuration
```javascript
// In index.template.js
exports.VENUE = "{{ VENUE }}"; // Supports template interpolation
```

## 🧪 Testing
- ✅ Build process works with Node.js v24.2.0 (using legacy OpenSSL provider)
- ✅ Confirmation modals display correctly for both submission types
- ✅ Query validation prevents invalid submissions
- ✅ Venue display appears in top banner
- ✅ Dark/light theme compatibility
- ✅ Data count check with loading states

### Procedure
1. Deployed NISAR dev cluster using dev-e2e (forward).

2. Logged into mozart via SSH and replaced deployed hysds_ui with this feature branch:
```
cd ~/mozart/ops
mv hysds_ui hysds_ui.bak
git clone https://github.com/hysds/hysds_ui.git
cd hysds_ui
git fetch -vv
git checkout HC-101
npm install
npm run build
fab -f ~/.sds/cluster.py -R mozart send_hysds_ui_conf
fab -f ~/.sds/cluster.py -R mozart build_hysds_ui
```

3. Tested figaro on-demand job interface by faceting on `job-failed` then clicked on "On-Demand". Note `Total Records` count in blue status box at top: 
<img width="2491" height="488" alt="Screenshot 2025-10-13 at 11 59 10 AM" src="https://github.com/user-attachments/assets/a9653bc9-1661-4d43-9e7f-0e9823bad9cc" />

4. Filled in `Tag` and selected `_Purge_jobs`. Clicked on `Submit` and note confirmation modal: 
<img width="576" height="329" alt="Screenshot 2025-10-13 at 12 00 30 PM" src="https://github.com/user-attachments/assets/9b78a67d-6a68-4d4e-9af4-2daebf4011eb" />

5. Clicked on "Submit Job" and verified job was submitted and completed fine.

6. Switched over to tosca and faceted on a dataset then clicked on "On-Demand". Note `Total Records` count in blue status box at top: 
<img width="2485" height="542" alt="Screenshot 2025-10-13 at 12 05 11 PM" src="https://github.com/user-attachments/assets/7d02cd04-37be-4013-a1cf-2c5a96a4e4f9" />

7. Filled in tag and selected `Purge datasets`. Clicked on `Submit` and noted confirmation modal. Noted that this job type is of submit type `individual` and verbiage in the confirmation modal explicitly details that one individual job will be submitted for the whole results set:  <img width="588" height="270" alt="Screenshot 2025-10-13 at 12 06 21 PM" src="https://github.com/user-attachments/assets/48a009cc-b76b-4e3c-8dcc-c90a59ab3e74" />

8. Clicked on "Submit Job" and verified job was submitted and completed fine.

9. Changed job to `Hello World` then clicked `Submit`. Noted that this job type is of submit type `iteration` and verbiage in the confirmation modal explicitly details that individual jobs per result will be submitted: 
<img width="541" height="283" alt="Screenshot 2025-10-13 at 12 09 10 PM" src="https://github.com/user-attachments/assets/1840d40a-169e-4367-9eb4-e259eadd6ac8" />

10. Clicked on `Cancel` to go back to On-Demand job screen. Modified the left textarea to append an `x` to the `triaged_job` value in the query. Noted that below the blue status screen a notification shows that the query was modified and asks user to click on `Data Count Check`:  <img width="2482" height="986" alt="Screenshot 2025-10-13 at 12 15 55 PM" src="https://github.com/user-attachments/assets/6e5cdb93-4027-45c4-ae5b-d022fdf0a1af" />

11. Noted that no matter what is modified on the form, the `Submit` button will remain disabled disallowing job submission.

12. Clicked on `Data Count Check` and noted status box show `N/A` total records and that the notification box requests the user to modify the query: <img width="1287" height="193" alt="Screenshot 2025-10-13 at 12 17 57 PM" src="https://github.com/user-attachments/assets/2daff92c-4dac-455e-b3f0-9e80f1dd10ae" />

13. Changed the value in the query from `triaged_jobx` to `L1_L_RSLC` then clicked on `Data Count Check`. Noted the record count found more than 1 result and the `Submit` button can now be clicked: <img width="2492" height="749" alt="Screenshot 2025-10-13 at 12 19 17 PM" src="https://github.com/user-attachments/assets/f7eef687-f5ab-4093-96e5-b84d10095927" />

14. Cancelled out back to tosca and verified the cluster venue is populated at the top right. Switched to figaro, clicked on dark mode and verified venue is populated and visible at the top right:
<img width="2493" height="183" alt="Screenshot 2025-10-13 at 12 20 50 PM" src="https://github.com/user-attachments/assets/5585527a-d6b3-4c63-9a65-4ec2f4a16ede" />
<img width="2470" height="153" alt="Screenshot 2025-10-13 at 12 20 59 PM" src="https://github.com/user-attachments/assets/ac66ff98-712e-4233-ac0f-0152689d431f" />






