### PR TITLE
Add ignore_unavailable=true to handle closed indices (HC-600)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.1.11",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/pages/Figaro/index.jsx
+++ b/src/pages/Figaro/index.jsx
@@ -52,6 +52,13 @@ class Figaro extends React.Component {
 
     const query = parseFacetQuery(e.body, "figaro-results");
     if (query) this.setState({ query });
+
+    // Add parameters to handle closed indices (HC-600)
+    if (e.url && !e.url.includes("ignore_unavailable")) {
+      const separator = e.url.includes("?") ? "&" : "?";
+      e.url = `${e.url}${separator}ignore_unavailable=true&allow_no_indices=true&expand_wildcards=open`;
+    }
+
     return e;
   };
 

--- a/src/pages/Tosca/index.jsx
+++ b/src/pages/Tosca/index.jsx
@@ -63,6 +63,13 @@ class Tosca extends React.Component {
 
     const query = parseFacetQuery(e.body, RESULTS_LIST_COMPONENT_ID);
     if (query) this.setState({ query });
+
+    // Add parameters to handle closed indices (HC-600)
+    if (e.url && !e.url.includes("ignore_unavailable")) {
+      const separator = e.url.includes("?") ? "&" : "?";
+      e.url = `${e.url}${separator}ignore_unavailable=true&allow_no_indices=true&expand_wildcards=open`;
+    }
+
     return e;
   };
 


### PR DESCRIPTION
## Summary

- Add `ignore_unavailable=true` query parameter to ES requests in Tosca and Figaro
- Modify `handleTransformRequest` to append the parameter to request URLs
- Prevents `index_closed_exception` errors when ISM policies close old indices

## Changes

- `src/pages/Tosca/index.jsx`: Add closed index handling in `handleTransformRequest`
- `src/pages/Figaro/index.jsx`: Add closed index handling in `handleTransformRequest`

## Test plan

- [ ] Verify Tosca loads correctly with closed indices
- [ ] Verify Figaro loads correctly with closed indices
- [ ] Test that searches work when some indices in wildcard pattern are closed

## Related

- Jira: [HC-600](https://hysds-core.atlassian.net/browse/HC-600)

[HC-600]: https://hysds-core.atlassian.net/browse/HC-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handles Elasticsearch closed indices to prevent request failures.
> 
> - In `src/pages/Tosca/index.jsx` and `src/pages/Figaro/index.jsx`, update `handleTransformRequest` to append `ignore_unavailable=true&allow_no_indices=true&expand_wildcards=open` to request `url` (if not already present)
> - Maintains query parsing via `parseFacetQuery` and last-updated timestamp updates
> - Bump `package.json` `version` to `1.2.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 684c31a53a55716d37d50ca89883f04df37eee21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->