### PR TITLE
HC-590: Expose job message for deduped jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hysds_ui",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/FigaroDataViewer/index.jsx
+++ b/src/components/FigaroDataViewer/index.jsx
@@ -104,13 +104,6 @@ export const FigaroDataViewer = (props) => {
                 </pre>
               </div>
             ) : null}
-            {res.status === "job-deduped" && res.dedup_msg ? (
-              <div className="figaro-code-format">
-                <pre>
-                  <code>{res.dedup_msg}</code>
-                </pre>
-              </div>
-            ) : null}
           </>
         );
       }
@@ -167,6 +160,14 @@ export const FigaroDataViewer = (props) => {
           dedup_job: {res.dedup_job}
         </a>
       ) : null}
+      {res.status === "job-deduped" && res.dedup_msg ? (
+        <div className="figaro-code-format">
+          <div>dedup_msg:</div>
+          <pre>
+            <code>{res.dedup_msg}</code>
+          </pre>
+        </div>
+      ) : null}
       <div>timestamp: {res["@timestamp"]}</div>
       {res.job ? <div>job: {res.job.name}</div> : null}
       {res.job && res.job.job_info && res.job.job_info.execute_node ? (
@@ -195,7 +196,7 @@ export const FigaroDataViewer = (props) => {
             Traceback
           </a>
         ) : null}
-        {res.msg_details || (res.status === "job-deduped" && res.dedup_msg) ? (
+        {res.msg_details ? (
           <a
             className="figaro-job-info-link"
             onClick={() => handleViewTypeChange("details")}

--- a/src/components/FigaroDataViewer/index.jsx
+++ b/src/components/FigaroDataViewer/index.jsx
@@ -104,6 +104,13 @@ export const FigaroDataViewer = (props) => {
                 </pre>
               </div>
             ) : null}
+            {res.status === "job-deduped" && res.dedup_msg ? (
+              <div className="figaro-code-format">
+                <pre>
+                  <code>{res.dedup_msg}</code>
+                </pre>
+              </div>
+            ) : null}
           </>
         );
       }
@@ -160,14 +167,6 @@ export const FigaroDataViewer = (props) => {
           dedup_job: {res.dedup_job}
         </a>
       ) : null}
-      {res.status === "job-deduped" && res.dedup_msg ? (
-        <div className="figaro-code-format">
-          <div>dedup_msg:</div>
-          <pre>
-            <code>{res.dedup_msg}</code>
-          </pre>
-        </div>
-      ) : null}
       <div>timestamp: {res["@timestamp"]}</div>
       {res.job ? <div>job: {res.job.name}</div> : null}
       {res.job && res.job.job_info && res.job.job_info.execute_node ? (
@@ -196,7 +195,7 @@ export const FigaroDataViewer = (props) => {
             Traceback
           </a>
         ) : null}
-        {res.msg_details ? (
+        {res.msg_details || (res.status === "job-deduped" && res.dedup_msg) ? (
           <a
             className="figaro-job-info-link"
             onClick={() => handleViewTypeChange("details")}

--- a/src/components/FigaroDataViewer/index.jsx
+++ b/src/components/FigaroDataViewer/index.jsx
@@ -104,6 +104,13 @@ export const FigaroDataViewer = (props) => {
                 </pre>
               </div>
             ) : null}
+            {res.status === "job-deduped" && res.dedup_msg ? (
+              <div className="figaro-code-format">
+                <pre>
+                  <code>{res.dedup_msg}</code>
+                </pre>
+              </div>
+            ) : null}
           </>
         );
       }
@@ -188,7 +195,7 @@ export const FigaroDataViewer = (props) => {
             Traceback
           </a>
         ) : null}
-        {res.msg_details ? (
+        {res.msg_details || (res.status === "job-deduped" && res.dedup_msg) ? (
           <a
             className="figaro-job-info-link"
             onClick={() => handleViewTypeChange("details")}

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -114,6 +114,13 @@ exports.FILTERS = [
     title: "Endpoint ID",
     type: "single",
   },
+  {
+    componentId: "job_deduped_detail",
+    dataField: "dedup_msg",
+    title: "Job Deduped Detail",
+    type: "single",
+    size: 1000,
+  },
 ];
 
 // TODO: TRY ADDING .KEYWORD TO COMPONENTID
@@ -138,6 +145,7 @@ exports.QUERY_LOGIC = {
     "timestamp",
     "endpoint_id",
     "redelivered",
+    "job_deduped_detail",
   ],
 };
 

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -114,13 +114,6 @@ exports.FILTERS = [
     title: "Endpoint ID",
     type: "single",
   },
-  {
-    componentId: "job_deduped_detail",
-    dataField: "dedup_msg",
-    title: "Job Deduped Detail",
-    type: "single",
-    size: 1000,
-  },
 ];
 
 // TODO: TRY ADDING .KEYWORD TO COMPONENTID
@@ -145,7 +138,6 @@ exports.QUERY_LOGIC = {
     "timestamp",
     "endpoint_id",
     "redelivered",
-    "job_deduped_detail",
   ],
 };
 

--- a/src/config/figaro.template.js
+++ b/src/config/figaro.template.js
@@ -152,6 +152,7 @@ exports.FIELDS = [
   "error",
   "traceback",
   "msg_details",
+  "dedup_msg",
   "tags",
   "job.name",
   "job.priority",


### PR DESCRIPTION
This update exposes the job message for deduped jobs in order for operators to gain better insight as to how a job got deduped.

Example of how it will look now:

<img width="2268" height="525" alt="image" src="https://github.com/user-attachments/assets/838b4381-9745-49ab-915e-41a2e9599fee" />
